### PR TITLE
feat: full installations of binaries on windows

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -97,6 +97,73 @@ jobs:
           command: test
           args: --release
 
+  test-non-elevated-install-windows:
+    if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"
+    name: Install test non-elevated (Windows)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Install binaries
+        shell: pwsh
+        run: |
+          cargo run -- client --version 0.74.2
+          cargo run -- node --version 0.80.3
+          cargo run -- testnet --version 0.1.4
+      - name: Check if safe is available in new shell session
+        shell: pwsh
+        run: |
+          if (!(Test-Path "$env:USERPROFILE\.safe\cli\safe.exe")) {
+            Write-Host "safe.exe does not exist"
+            exit 1
+          }
+          if (!(Test-Path "$env:USERPROFILE\.safe\node\safenode.exe")) {
+            Write-Host "safenode.exe does not exist"
+            exit 1
+          }
+          if (!(Test-Path "$env:USERPROFILE\.safe\node\testnet.exe")) {
+            Write-Host "testnet.exe does not exist"
+            exit 1
+          }
+
+          # For security reasons, the GHA infrastructure prevents environment variables
+          # being modified easily, so we need to refer to the binaries with their full paths.
+          # Other manual testing has proven that the changes to the Path environment variable do
+          # take effect.
+          $output = & "${env:USERPROFILE}\.safe\cli\safe.exe" --version
+          $version = $output | Select-String -Pattern "sn_cli (\d+\.\d+\.\d+)"
+          $versionNumber = $version.Matches.Groups[1].Value
+          if ($versionNumber -eq "0.74.2") {
+            Write-Host "The correct version of safe has been installed"
+          } else {
+            Write-Host "The correct version of safe has not been installed"
+            exit 1
+          }
+
+          $output = & "${env:USERPROFILE}\.safe\node\safenode.exe" --version
+          $version = $output | Select-String -Pattern "sn_node (\d+\.\d+\.\d+)"
+          $versionNumber = $version.Matches.Groups[1].Value
+          if ($versionNumber -eq "0.80.3") {
+            Write-Host "The correct version of safenode has been installed"
+          } else {
+            Write-Host "The correct version of safenode has not been installed"
+            exit 1
+          }
+
+          $output = & "${env:USERPROFILE}\.safe\node\testnet.exe" --version
+          $version = $output | Select-String -Pattern "testnet (\d+\.\d+\.\d+)"
+          $versionNumber = $version.Matches.Groups[1].Value
+          if ($versionNumber -eq "0.1.4") {
+            Write-Host "The correct version of testnet has been installed"
+          } else {
+            Write-Host "The correct version of testnet has not been installed"
+            exit 1
+          }
+
   test-non-elevated-install-linux:
     if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"
     name: Install test non-elevated (Linux)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ serde_json = "1.0"
 tar = "0.4"
 tokio = { version = "1.26", features = ["full"] }
 
+[target.'cfg(windows)'.dependencies]
+winreg = "0.7"
 [target.'cfg(unix)'.dependencies]
 users = "0.11"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -201,7 +201,9 @@ async fn install(
         .await?
     }
 
-    let settings_file_path = safe_dir_path.join("safeup.json");
+    let config_dir_path =
+        dirs_next::config_dir().ok_or_else(|| eyre!("Could not retrieve user's home directory"))?;
+    let settings_file_path = config_dir_path.join(".safe").join("safeup.json");
     let mut settings = Settings::read(&settings_file_path)?;
     match asset_type {
         AssetType::Client => settings.safe_path = bin_path,

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,6 +108,7 @@ async fn main() -> Result<()> {
             no_modify_shell_profile,
             version,
         }) => {
+            install::check_prerequisites()?;
             install(
                 AssetType::Client,
                 SAFE_BUCKET_NAME,
@@ -122,6 +123,7 @@ async fn main() -> Result<()> {
             no_modify_shell_profile,
             version,
         }) => {
+            install::check_prerequisites()?;
             install(
                 AssetType::Node,
                 SAFENODE_BUCKET_NAME,
@@ -136,6 +138,7 @@ async fn main() -> Result<()> {
             no_modify_shell_profile,
             version,
         }) => {
+            install::check_prerequisites()?;
             install(
                 AssetType::Testnet,
                 TESTNET_BUCKET_NAME,
@@ -191,6 +194,7 @@ async fn install(
 
     if !running_elevated && !no_modify_shell_profile {
         install::configure_shell_profile(
+            &dest_dir_path.clone(),
             &get_shell_profile_path(&home_dir_path),
             &home_dir_path.join(".safe").join("env"),
         )


### PR DESCRIPTION
- ae38f81 **feat: full installations of binaries on windows**

  For installation on Windows, a function for checking prerequisites was introduced, and the
  `configure_shell_profile` function was implemented.

  The prerequisite check tests whether the Visual C++ Redistributable is installed by checking the
  registry. It would have been possible to install it if it was missing, but you run into
  complications there with the need for elevated privileges. Instead, we simply just suggest to the
  user that they download and install it. On Linux/macOS, this function is left empty because no
  prerequisites are required.

  The `configure_shell_profile` function puts the location of `safe` on the user Path variable. To
  make the change permanent, it needs to be done by changing a registry value.

  Test coverage was not provided for either of these functions because it would involve mocking out
  the registry usage, and that didn't really seem worth it.

- 770b3cb **chore: use config directory for safeup config**

  As things stand at the moment, users often delete the ~/.safe directory, which would remove the
  installed locations of the binaries. As protection from that, we can keep the installed locations
  file in the OS config directory.

- a940a85 **ci: integration test for windows installations**

  Provides a Windows integration test to check that the correct versions are installed. Ideally we
  would have been able to make use of two shell sessions to check the Path environment variable
  change was being picked up, but I think the GHA infrastructure prevents easy modification of them.
  Still the test does make sure the files are in the right place and the correct versions are
  downloaded.

  Also fix some clippy errors and applies conditional compilation to avoid compiler warnings on
  different operating systems.