### PR TITLE
fix: invalid branch reference

### DIFF
--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -8,8 +8,8 @@ env:
 jobs:
   bump_version:
     if: |
-      github.repository_owner == 'jacderida' &&
-      !startsWith(github.event.head_commit.message, 'chore: release')
+      github.repository_owner == 'maidsafe' &&
+      !startsWith(github.event.head_commit.message, 'chore(release):')
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The workflow was copied from a personal project, so the repo owner was wrong.