### PR TITLE
fix: compile tests correctly on windows

### DIFF
--- a/src/install.rs
+++ b/src/install.rs
@@ -322,6 +322,9 @@ mod test {
     use std::fs::File;
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
+    #[cfg(windows)]
+    use std::path::PathBuf;
+    #[cfg(unix)]
     use std::path::{Path, PathBuf};
 
     /// These may seem pointless, but they are useful for when the tests run on different


### PR DESCRIPTION
Code referenced is slightly different between platforms, so we need to make some `use` directives conditional.