### PR TITLE
feat: use `~/.local/bin` as install location

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -111,21 +111,21 @@ jobs:
       - name: Install binaries
         shell: pwsh
         run: |
-          cargo run -- client --version 0.74.2
-          cargo run -- node --version 0.80.3
-          cargo run -- testnet --version 0.1.4
+          cargo run -- client --version 0.77.27
+          cargo run -- node --version 0.83.25
+          cargo run -- testnet --version 0.1.29
       - name: Check if safe is available in new shell session
         shell: pwsh
         run: |
-          if (!(Test-Path "$env:USERPROFILE\.safe\cli\safe.exe")) {
+          if (!(Test-Path "$env:USERPROFILE\safe\safe.exe")) {
             Write-Host "safe.exe does not exist"
             exit 1
           }
-          if (!(Test-Path "$env:USERPROFILE\.safe\node\safenode.exe")) {
+          if (!(Test-Path "$env:USERPROFILE\safe\safenode.exe")) {
             Write-Host "safenode.exe does not exist"
             exit 1
           }
-          if (!(Test-Path "$env:USERPROFILE\.safe\node\testnet.exe")) {
+          if (!(Test-Path "$env:USERPROFILE\safe\testnet.exe")) {
             Write-Host "testnet.exe does not exist"
             exit 1
           }
@@ -134,33 +134,39 @@ jobs:
           # being modified easily, so we need to refer to the binaries with their full paths.
           # Other manual testing has proven that the changes to the Path environment variable do
           # take effect.
-          $output = & "${env:USERPROFILE}\.safe\cli\safe.exe" --version
+          $output = & "${env:USERPROFILE}\safe\safe.exe" --version
           $version = $output | Select-String -Pattern "sn_cli (\d+\.\d+\.\d+)"
           $versionNumber = $version.Matches.Groups[1].Value
-          if ($versionNumber -eq "0.74.2") {
+          if ($versionNumber -eq "0.77.27") {
             Write-Host "The correct version of safe has been installed"
           } else {
             Write-Host "The correct version of safe has not been installed"
+            Write-Host "We expected version 0.77.27"
+            Write-Host "The downloaded binary has $versionNumber"
             exit 1
           }
 
-          $output = & "${env:USERPROFILE}\.safe\node\safenode.exe" --version
-          $version = $output | Select-String -Pattern "sn_node (\d+\.\d+\.\d+)"
+          $output = & "${env:USERPROFILE}\safe\safenode.exe" --version
+          $version = $output | Select-String -Pattern "safenode cli (\d+\.\d+\.\d+)"
           $versionNumber = $version.Matches.Groups[1].Value
-          if ($versionNumber -eq "0.80.3") {
+          if ($versionNumber -eq "0.83.25") {
             Write-Host "The correct version of safenode has been installed"
           } else {
             Write-Host "The correct version of safenode has not been installed"
+            Write-Host "We expected version 0.83.25"
+            Write-Host "The downloaded binary has $versionNumber"
             exit 1
           }
 
-          $output = & "${env:USERPROFILE}\.safe\node\testnet.exe" --version
+          $output = & "${env:USERPROFILE}\safe\testnet.exe" --version
           $version = $output | Select-String -Pattern "testnet (\d+\.\d+\.\d+)"
           $versionNumber = $version.Matches.Groups[1].Value
-          if ($versionNumber -eq "0.1.4") {
+          if ($versionNumber -eq "0.1.29") {
             Write-Host "The correct version of testnet has been installed"
           } else {
             Write-Host "The correct version of testnet has not been installed"
+            Write-Host "We expected version 0.1.29"
+            Write-Host "The downloaded binary has $versionNumber"
             exit 1
           }
 
@@ -178,9 +184,9 @@ jobs:
       - name: Install binaries
         shell: bash
         run: |
-          cargo run -- client --version 0.74.2
-          cargo run -- node --version 0.80.3
-          cargo run -- testnet --version 0.1.4
+          cargo run -- client --version 0.77.27
+          cargo run -- node --version 0.83.25
+          cargo run -- testnet --version 0.1.29
       - name: Check if safe is available in new shell session
         shell: bash
         run: |
@@ -191,33 +197,39 @@ jobs:
           # the test does prove that the env file modifies PATH correctly and
           # that the installs of the binaries are available from their local
           # locations.
-          source ~/.safe/env
+          source ~/.config/safe/env
 
-          [[ -f "$HOME/.safe/cli/safe" ]] || { echo "safe not in expected location"; exit 1; }
-          [[ -f "$HOME/.safe/node/safenode" ]] || { echo "safenode not in expected location"; exit 1; }
-          [[ -f "$HOME/.safe/node/testnet" ]] || { echo "testnet not in expected location"; exit 1; }
+          [[ -f "$HOME/.local/bin/safe" ]] || { echo "safe not in expected location"; exit 1; }
+          [[ -f "$HOME/.local/bin/safenode" ]] || { echo "safenode not in expected location"; exit 1; }
+          [[ -f "$HOME/.local/bin/testnet" ]] || { echo "testnet not in expected location"; exit 1; }
 
           version=$(safe --version | awk '{ print $2 }')
-          if [[ "$version" == "0.74.2" ]]; then
+          if [[ "$version" == "0.77.27" ]]; then
             echo "The correct version of safe has been installed"
           else
             echo "The correct version of safe has not been installed"
+            echo "We expected 0.77.27"
+            echo "The downloaded binary has $version"
             exit 1
           fi
 
-          version=$(safenode --version | awk '{ print $2 }')
-          if [[ "$version" == "0.80.3" ]]; then
+          version=$(safenode --version | awk '{ print $3 }')
+          if [[ "$version" == "0.83.25" ]]; then
             echo "The correct version of safenode has been installed"
           else
             echo "The correct version of safenode has not been installed"
+            echo "We expected 0.83.25"
+            echo "The downloaded binary has $version"
             exit 1
           fi
 
           version=$(testnet --version | awk '{ print $2 }')
-          if [[ "$version" == "0.1.4" ]]; then
+          if [[ "$version" == "0.1.29" ]]; then
             echo "The correct version of testnet has been installed"
           else
             echo "The correct version of testnet has not been installed"
+            echo "We expected 0.1.29"
+            echo "The downloaded binary has $version"
             exit 1
           fi
 
@@ -236,9 +248,9 @@ jobs:
         shell: bash
         run: |
           cargo build --release
-          sudo ./target/release/safeup client --version 0.74.2
-          sudo ./target/release/safeup node --version 0.80.3
-          sudo ./target/release/safeup testnet --version 0.1.4
+          sudo ./target/release/safeup client --version 0.77.27
+          sudo ./target/release/safeup node --version 0.83.25
+          sudo ./target/release/safeup testnet --version 0.1.29
 
           [[ -f "/usr/local/bin/safe" ]] || { echo "safe not in expected location"; exit 1; }
           [[ -f "/usr/local/bin/safenode" ]] || { echo "safenode not in expected location"; exit 1; }
@@ -247,26 +259,32 @@ jobs:
           # Due to installation at /usr/local/bin, the binaries should be
           # immediately available in the same shell session.
           version=$(safe --version | awk '{ print $2 }')
-          if [[ "$version" == "0.74.2" ]]; then
+          if [[ "$version" == "0.77.27" ]]; then
             echo "The correct version of safe has been installed"
           else
             echo "The correct version of safe has not been installed"
+            echo "We expected 0.77.27"
+            echo "The downloaded binary has $version"
             exit 1
           fi
 
-          version=$(safenode --version | awk '{ print $2 }')
-          if [[ "$version" == "0.80.3" ]]; then
+          version=$(safenode --version | awk '{ print $3 }')
+          if [[ "$version" == "0.83.25" ]]; then
             echo "The correct version of safenode has been installed"
           else
             echo "The correct version of safenode has not been installed"
+            echo "We expected 0.83.25"
+            echo "The downloaded binary has $version"
             exit 1
           fi
 
           version=$(testnet --version | awk '{ print $2 }')
-          if [[ "$version" == "0.1.4" ]]; then
+          if [[ "$version" == "0.1.29" ]]; then
             echo "The correct version of testnet has been installed"
           else
             echo "The correct version of testnet has not been installed"
+            echo "We expected 0.1.29"
+            echo "The downloaded binary has $version"
             exit 1
           fi
 
@@ -285,35 +303,41 @@ jobs:
       - name: Install binaries
         shell: zsh {0}
         run: |
-          cargo run -- client --version 0.74.2
-          cargo run -- node --version 0.80.3
-          cargo run -- testnet --version 0.1.4
+          cargo run -- client --version 0.77.27
+          cargo run -- node --version 0.83.25
+          cargo run -- testnet --version 0.1.29
 
           [[ -f "/usr/local/bin/safe" ]] || { echo "safe not in expected location"; exit 1; }
           [[ -f "/usr/local/bin/safenode" ]] || { echo "safenode not in expected location"; exit 1; }
           [[ -f "/usr/local/bin/testnet" ]] || { echo "testnet not in expected location"; exit 1; }
 
           version=$(safe --version | awk '{ print $2 }')
-          if [[ "$version" == "0.74.2" ]]; then
+          if [[ "$version" == "0.77.27" ]]; then
             echo "The correct version of safe has been installed"
           else
             echo "The correct version of safe has not been installed"
+            echo "We expected 0.77.27"
+            echo "The downloaded binary has $version"
             exit 1
           fi
 
-          version=$(safenode --version | awk '{ print $2 }')
-          if [[ "$version" == "0.80.3" ]]; then
+          version=$(safenode --version | awk '{ print $3 }')
+          if [[ "$version" == "0.83.25" ]]; then
             echo "The correct version of safenode has been installed"
           else
             echo "The correct version of safenode has not been installed"
+            echo "We expected 0.83.25"
+            echo "The downloaded binary has $version"
             exit 1
           fi
 
           version=$(testnet --version | awk '{ print $2 }')
-          if [[ "$version" == "0.1.4" ]]; then
+          if [[ "$version" == "0.1.29" ]]; then
             echo "The correct version of testnet has been installed"
           else
             echo "The correct version of testnet has not been installed"
+            echo "We expected 0.1.29"
+            echo "The downloaded binary has $version"
             exit 1
           fi
 
@@ -329,5 +353,5 @@ jobs:
           toolchain: stable
           override: true
 
-      - name: Cargo publish dry run
+      - name: dry run publish
         run: cargo publish --dry-run

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,6 +12,30 @@ env:
   RUSTFLAGS: "-D warnings"
 
 jobs:
+  # The code in this crate uses lots of conditional compilation for cross-platform capabilities.
+  # Therefore, it's important we make sure it can build on both the Windows and Unix OS families.
+  build:
+    name: build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+          - os: macos-latest
+            target: x86_64-apple-darwin
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        id: toolchain
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - shell: bash
+        run: cargo build --all-targets --all-features
   checks:
     if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"
     name: Clippy & fmt

--- a/src/install.rs
+++ b/src/install.rs
@@ -39,13 +39,10 @@ const VCPP_REDIST_URL: &str = "https://download.microsoft.com/download/9/3/F/93F
 const SET_PATH_FILE_CONTENT: &str = indoc! {r#"
     #!/bin/sh
     case ":${PATH}:" in
-        *:"$HOME/.safe/cli":*)
-            ;;
-        *:"$HOME/.safe/node":*)
+        *:"$HOME/.local/bin":*)
             ;;
         *)
-            export PATH="$HOME/.safe/cli:$PATH"
-            export PATH="$HOME/.safe/node:$PATH"
+            export PATH="$HOME/.local/bin:$PATH"
             ;;
     esac
 "#};


### PR DESCRIPTION
- 56d4698 **feat: use `~/.local/bin` as install location**

  BREAKING CHANGE: rather than use `~/.safe/cli` and `~/.safe/node`, we can put all the binaries in
  `~/.local/bin`, which is part of the XDG Base Directory Specification. This does not change the
  install location for when we're running as the root user.

  On Windows, the install location is changed slightly, to use `%USERPROFILE%\safe`, rather than
  `%USERPROFILE%\.safe` since the use of `.` prefixed directories are not as common on Windows and
  wouldn't have them marked as hidden by software like Windows Explorer. There is no common location
  on Windows to put binaries without having Administrator access.

  The integration tests are updated to take this new location into account, and the version numbers of
  the components are changed to use up-to-date numbers from releases in the new repository.

- 82d1f3e **ci: provide build job**

  The code in this crate uses lots of conditional compilation for cross-platform capability.

  Therefore, it's important before release that we make sure the code can build properly on both the
  Windows and Unix OS families.