### PR TITLE
Install Scripts for Unix and Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,39 @@
 # safeup
 
-Install and update safe-related components.
+Simple utility for installing and updating safe-related components.
 
-## Installations
+## Install
 
-Use the `client` or `node` commands to install the latest versions of the `safe` or `safenode` binaries. You can either run the process with `sudo`, in which case the binaries will be installed to `/usr/local/bin`, or if you run as the current user, they will be installed to `~/.safe/cli`, or `~/.safe/node` respectively.
+### Linux/macOS
+
+You can choose to run the installation for `safeup` as the current user or with `sudo`. The difference between them is the install location and modification of the shell profile. If running with `sudo`, `safeup` will be installed to `/usr/local/bin`; otherwise it will be installed to `~/.local/bin` and the Bash shell profile will be modified to add that location to the `PATH` variable. For almost any Linux-based or macOS installation, `/usr/local/bin` is already available on `PATH` as standard.
+
+To install as `sudo`, use the following:
+```
+curl -sSL https://raw.githubusercontent.com/maidsafe/safeup/main/install.sh | sudo bash
+```
+
+Otherwise:
+```
+curl -sSL https://raw.githubusercontent.com/maidsafe/safeup/main/install.sh | bash
+```
+
+This process will download and install `safeup` for your platform, then run it to have it install the `safe` client binary.
+
+### Windows
+
+On Windows, we are currently not supporting installing either `safeup` or the other binaries with Administrator privileges, so there is only one command:
+```
+iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/jacderida/safeup/install-scripts/install.ps1'))
+```
+
+On all platforms, the above processes will download and install `safeup` for your platform, then run it to have it install the `safe` client binary.
+
+## Usage
+
+Use the `client`, `node` or `testnet` commands to install the latest versions of the `safe`, `safenode` or `testnet` binaries, respectively. 
+
+As above, you can choose to run `safeup` using `sudo`, depending on where you'd like your binaries installed. Again, this does not apply to Windows, where we don't support running with Administrator privileges.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This process will download and install `safeup` for your platform, then run it t
 
 On Windows, we are currently not supporting installing either `safeup` or the other binaries with Administrator privileges, so there is only one command:
 ```
-iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/jacderida/safeup/install-scripts/install.ps1'))
+iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/maidsafe/safeup/main/install.ps1'))
 ```
 
 On all platforms, the above processes will download and install `safeup` for your platform, then run it to have it install the `safe` client binary.

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,28 @@
+Write-Host "**************************************"
+Write-Host "*                                    *"
+Write-Host "*         Installing safeup          *"
+Write-Host "*                                    *"
+Write-Host "**************************************"
+
+$response = Invoke-WebRequest `
+    -Uri "https://api.github.com/repos/maidsafe/safeup/releases/latest" `
+    -UseBasicParsing
+$json = $response | ConvertFrom-Json
+$version = $json.tag_name.TrimStart('v')
+Write-Host "Latest version of safeup is $version"
+$asset = $json.assets | Where-Object { $_.name -match "safeup-$version-x86_64-pc-windows-msvc.tar.gz" }
+$downloadUrl = $asset.browser_download_url
+
+$archivePath = Join-Path $env:TEMP "safeup.tar.gz"
+Invoke-WebRequest -Uri $downloadUrl -OutFile $archivePath
+
+$destination = Join-Path $env:USERPROFILE "safe"
+New-Item -ItemType Directory -Force -Path $destination
+tar -xf $archivePath -C $destination
+Remove-Item $archivePath
+$safeupExePath = Join-Path $destination "safeup.exe"
+
+Write-Host "Now running safeup to install the safe client..."
+Start-Process -FilePath $safeupExePath -ArgumentList "client"
+Write-Host "If you wish to install safenode, please run 'safeup node'."
+Write-Host "You may need to start a new session for safeup to become available."

--- a/install.sh
+++ b/install.sh
@@ -63,7 +63,11 @@ function install_safeup() {
 function post_install() {
   echo "Now running safeup to install the safe client..."
   $target_dir/safeup client
-  echo "If you wish to install safenode, please run 'safeup node'."
+  if [[ $EUID -eq 0 ]]; then
+    echo "If you wish to install safenode, please run 'sudo safeup node'."
+  else
+    echo "If you wish to install safenode, please run 'safeup node'."
+  fi
 }
 
 print_banner

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+function print_banner() {
+  echo "**************************************"
+  echo "*                                    *"
+  echo "*         Installing safeup          *"
+  echo "*                                    *"
+  echo "**************************************"
+}
+
+function detect_os() {
+  os=$(uname -s)
+  case "$os" in
+    Linux*) os=linux ;;
+    Darwin*) os=mac ;;
+    *) echo "Unknown operating system"; exit 1 ;;
+  esac
+}
+
+function detect_arch() {
+  arch=$(uname -m)
+  case "$arch" in
+    x86_64*) 
+      if [[ $os == "mac" ]]; then
+        arch_triple="x86_64-apple-darwin"
+      else
+        arch_triple="x86_64-unknown-$os-musl"
+      fi
+      ;;
+    aarch64*) arch_triple="aarch64-unknown-$os-musl" ;;
+    *) echo "Architecture $arch not supported"; exit 1 ;;
+  esac
+  echo "Will retrieve safeup for $arch_triple architecture"
+}
+
+function get_latest_version() {
+  release_data=$(curl --silent "https://api.github.com/repos/maidsafe/safeup/releases/latest")
+  version=$(echo "$release_data" | awk -F': ' '/"tag_name":/ {print $2}' | \
+    sed 's/"//g' | sed 's/,//g' | sed 's/v//g')
+  download_url=$(echo "$release_data" | \
+    awk -F': ' '/"browser_download_url":/ {print $2 $3}' | \
+    grep "safeup-$version-$arch_triple.tar.gz" | sed 's/"//g' | sed 's/,//g')
+  echo "Latest version of safeup is $version"
+}
+
+function install_safeup() {
+  if [[ $EUID -eq 0 ]]; then
+    target_dir="/usr/local/bin"
+  else
+    target_dir="$HOME/.local/bin"
+    mkdir -p "$target_dir"
+  fi
+
+  temp_dir=$(mktemp -d)
+  curl -L "$download_url" -o "$temp_dir/safeup.tar.gz"
+  tar -xzf "$temp_dir/safeup.tar.gz" -C "$temp_dir"
+  mv "$temp_dir/safeup" "$target_dir/safeup"
+  chmod +x "$target_dir/safeup"
+  rm -rf "$temp_dir"
+  echo "safeup installed to $target_dir/safeup"
+}
+
+function post_install() {
+  echo "Now running safeup to install the safe client..."
+  $target_dir/safeup client
+  echo "If you wish to install safenode, please run 'safeup node'."
+}
+
+print_banner
+detect_os
+detect_arch
+get_latest_version
+install_safeup
+post_install

--- a/src/install.rs
+++ b/src/install.rs
@@ -248,6 +248,7 @@ pub async fn configure_shell_profile(
             "To make safe available in this session run 'source {}'",
             path_config_file_path
         );
+        println!("Alternatively you can start a new session");
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,6 +108,11 @@ async fn main() -> Result<()> {
             no_modify_shell_profile,
             version,
         }) => {
+            println!("**************************************");
+            println!("*                                    *");
+            println!("*          Installing safe           *");
+            println!("*                                    *");
+            println!("**************************************");
             install::check_prerequisites()?;
             install(
                 AssetType::Client,
@@ -123,6 +128,11 @@ async fn main() -> Result<()> {
             no_modify_shell_profile,
             version,
         }) => {
+            println!("**************************************");
+            println!("*                                    *");
+            println!("*          Installing safenode       *");
+            println!("*                                    *");
+            println!("**************************************");
             install::check_prerequisites()?;
             install(
                 AssetType::Node,
@@ -138,6 +148,11 @@ async fn main() -> Result<()> {
             no_modify_shell_profile,
             version,
         }) => {
+            println!("**************************************");
+            println!("*                                    *");
+            println!("*          Installing testnet        *");
+            println!("*                                    *");
+            println!("**************************************");
             install::check_prerequisites()?;
             install(
                 AssetType::Testnet,
@@ -148,10 +163,7 @@ async fn main() -> Result<()> {
             )
             .await
         }
-        None => {
-            println!("interactive gui");
-            Ok(())
-        }
+        None => Ok(()),
     }
 }
 


### PR DESCRIPTION
- aabc109 **feat: provide unix-based install script**

  This script detects the OS, then CPU architecture, then obtains the latest version of `safeup`. With
  that information, it downloads the relevant `safeup` binary, extracts it, then uses it to install
  the client by default.

  The script is intended to be compatible with both Linux and macOS, but also x86_64 and ARM CPU
  architectures.

  A modification is also made to safeup to inform the user that as an alternative to sourcing the `env`
  file to make the modified `PATH` available, they can also start a new session.

- 71776be **feat: provide powershell install script**

  This script is almost the same as the Unix one, except it doesn't need to detect OS and doesn't
  detect CPU architecture, since currently we only support `x86_64` for Windows.

- 82afa33 **docs: provide installation instructions**

- 40fa23f **feat: use banners for install process**

  These are not just frivolous; based on my testing, they make it more apparent for the user that an
  install process is happening.