### PR TITLE
feat: do not install client by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "safeup"
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
-description = "CLI for installing components for access the Safe Network"
+description = "CLI for installing components for accessing the Safe Network"
 license = "GPL-3.0"
 version = "0.2.1"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ curl -sSL https://raw.githubusercontent.com/maidsafe/safeup/main/install.sh | ba
 
 This process will download and install `safeup` for your platform, then run it to have it install the `safe` client binary.
 
+The install script also accepts two flag arguments, namely `--client` and `--node`. If either are used, the script will invoke the installed `safeup` binary to install `safe` and `safenode`, respectively, without having to run either as an additional post-install step.
+
+To use these options as `sudo`:
+```
+curl -sSL https://raw.githubusercontent.com/jacderida/safeup/install-scripts/install.sh | sudo bash -s -- --client
+```
+
+Otherwise:
+```
+curl -sSL https://raw.githubusercontent.com/jacderida/safeup/install-scripts/install.sh | bash -s -- --client
+```
+
 ### Windows
 
 On Windows, we are currently not supporting installing either `safeup` or the other binaries with Administrator privileges, so there is only one command:
@@ -27,7 +39,9 @@ On Windows, we are currently not supporting installing either `safeup` or the ot
 iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/maidsafe/safeup/main/install.ps1'))
 ```
 
-On all platforms, the above processes will download and install `safeup` for your platform, then run it to have it install the `safe` client binary.
+The Powershell installer does not support the `--client` or `--node` arguments because it's not possible to pass them when the script is downloaded.
+
+Therefore, installing any components on Windows is an additional post-safeup-installation step.
 
 ## Usage
 

--- a/install.ps1
+++ b/install.ps1
@@ -22,7 +22,5 @@ tar -xf $archivePath -C $destination
 Remove-Item $archivePath
 $safeupExePath = Join-Path $destination "safeup.exe"
 
-Write-Host "Now running safeup to install the safe client..."
-Start-Process -FilePath $safeupExePath -ArgumentList "client"
-Write-Host "If you wish to install safenode, please run 'safeup node'."
 Write-Host "You may need to start a new session for safeup to become available."
+Write-Host "When safeup is available, please run 'safeup --help' to see how to install network components."


### PR DESCRIPTION
BREAKING CHANGE: for the Unix installation, the default client install is removed.

I quickly realised this behaviour was quite silly, because you might run the installer on a node machine and have no interest in the client.

As an alternative, `--client` and `--node` arguments were added to the install script to support installing either of these without an additional post-install step.

They have been left out of the Windows install script because Powershell does not support sending the arguments when the script is downloaded, like you can with Bash.