### PR TITLE
feat: set user path variable for windows

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -16,11 +16,19 @@ $downloadUrl = $asset.browser_download_url
 $archivePath = Join-Path $env:TEMP "safeup.tar.gz"
 Invoke-WebRequest -Uri $downloadUrl -OutFile $archivePath
 
-$destination = Join-Path $env:USERPROFILE "safe"
-New-Item -ItemType Directory -Force -Path $destination
-tar -xf $archivePath -C $destination
+$safePath = Join-Path $env:USERPROFILE "safe"
+New-Item -ItemType Directory -Force -Path $safePath
+tar -xf $archivePath -C $safePath
 Remove-Item $archivePath
-$safeupExePath = Join-Path $destination "safeup.exe"
+$safeupExePath = Join-Path $safePath "safeup.exe"
+
+if ($currentPath -notlike "*$safePath*") {
+    $newPath = $currentPath + ";" + $safePath
+    [Environment]::SetEnvironmentVariable("PATH", $newPath, [EnvironmentVariableTarget]::User)
+    Write-Host "Added $safePath to user PATH"
+} else {
+    Write-Host "Path $safePath is already in user PATH"
+}
 
 Write-Host "You may need to start a new session for safeup to become available."
 Write-Host "When safeup is available, please run 'safeup --help' to see how to install network components."


### PR DESCRIPTION
If we are not going to install the client by default, we will need to add the binary location for `safeup` to PATH so that it's accessible in the next shell session.