### PR TITLE
Fix Some Windows Install Issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ curl -sSL https://raw.githubusercontent.com/maidsafe/safeup/main/install.sh | ba
 
 On Windows, we are currently not supporting installing either `safeup` or the other binaries with Administrator privileges, so there is only one command:
 ```
-iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/maidsafe/safeup/main/install.ps1'))
+iex (Invoke-RestMethod -Uri "https://raw.githubusercontent.com/maidsafe/safeup/main/install.ps1")
 ```
 
 The Powershell installer does not support the `--client` or `--node` arguments because it's not possible to pass them when the script is downloaded.

--- a/install.ps1
+++ b/install.ps1
@@ -1,3 +1,5 @@
+$ErrorActionPreference = "Stop"
+
 Write-Host "**************************************"
 Write-Host "*                                    *"
 Write-Host "*         Installing safeup          *"
@@ -10,18 +12,19 @@ $response = Invoke-WebRequest `
 $json = $response | ConvertFrom-Json
 $version = $json.tag_name.TrimStart('v')
 Write-Host "Latest version of safeup is $version"
-$asset = $json.assets | Where-Object { $_.name -match "safeup-$version-x86_64-pc-windows-msvc.tar.gz" }
+$asset = $json.assets | Where-Object { $_.name -match "safeup-$version-x86_64-pc-windows-msvc.zip" }
 $downloadUrl = $asset.browser_download_url
 
-$archivePath = Join-Path $env:TEMP "safeup.tar.gz"
+$archivePath = Join-Path $env:TEMP "safeup.zip"
 Invoke-WebRequest -Uri $downloadUrl -OutFile $archivePath
 
 $safePath = Join-Path $env:USERPROFILE "safe"
 New-Item -ItemType Directory -Force -Path $safePath
-tar -xf $archivePath -C $safePath
+Expand-Archive -Path $archivePath -DestinationPath $safePath
 Remove-Item $archivePath
 $safeupExePath = Join-Path $safePath "safeup.exe"
 
+$currentPath = [Environment]::GetEnvironmentVariable("PATH", [EnvironmentVariableTarget]::User)
 if ($currentPath -notlike "*$safePath*") {
     $newPath = $currentPath + ";" + $safePath
     [Environment]::SetEnvironmentVariable("PATH", $newPath, [EnvironmentVariableTarget]::User)

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 install_client=0
 install_node=0
 


### PR DESCRIPTION
- f1d6a31 **refactor: use zip rather than tar archive**

  On Windows it's easier to use the zip file distribution rather than tar, because Powershell has
  native functions for extracting zip files.

  Also set both install scripts to stop on error. If they don't, messages can be displayed that make
  things confusing for the user.

- 0a8410a **docs: alt mechanism for downloading install script**

  Use `Invoke-RestMethod` rather than `System.Net.WebClient` for downloading the install script. When
  using the latter, we encountered issues with Powershell having an old version of TLS.