### PR TITLE
Install Fixes

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -20,7 +20,7 @@ Invoke-WebRequest -Uri $downloadUrl -OutFile $archivePath
 
 $safePath = Join-Path $env:USERPROFILE "safe"
 New-Item -ItemType Directory -Force -Path $safePath
-Expand-Archive -Path $archivePath -DestinationPath $safePath
+Expand-Archive -Path $archivePath -DestinationPath $safePath -Force
 Remove-Item $archivePath
 $safeupExePath = Join-Path $safePath "safeup.exe"
 

--- a/install.sh
+++ b/install.sh
@@ -64,6 +64,7 @@ function detect_arch() {
         arch_triple="aarch64-unknown-$os-musl"
       fi
       ;;
+    armv7*) arch_triple="armv7-unknown-$os-musleabihf" ;;
     *) echo "Architecture $arch not supported"; exit 1 ;;
   esac
   echo "Will retrieve safeup for $arch_triple architecture"


### PR DESCRIPTION
- e5ab435 **fix: use `-Force` option on zip extraction**

  If the Powershell install script runs again and there's a `safe.exe` that's been previously
  downloaded, the `Extract-Archive` treats this as an error. The `-Force` option can be used to
  overwrite the old binary, which should be fine here.

- 6761838 **feat: support armv7 architecture**

  During the InstallNet testnet, one of our users was using testing on a BananaPi, which is an older
  Raspberry Pi device that has this architecture. We have `armv7` binaries available, so we should be
  able to support this.