### PR TITLE
fix: relax check for shell on macos

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -239,11 +239,19 @@ fn get_shell_profile_path() -> Result<PathBuf> {
 #[cfg(target_os = "macos")]
 fn get_shell_profile_path() -> Result<PathBuf> {
     let profile_file_name = match std::env::var("SHELL") {
-        Ok(shell) => match shell.as_str() {
-            "/bin/bash" => ".bashrc",
-            "/bin/zsh" => ".zshrc",
-            _ => return Err(eyre!("shell {shell} is not supported by safeup")),
-        },
+        Ok(shell) => {
+            let pb = PathBuf::from(shell.clone());
+            let shell_bin_name = pb
+                .file_stem()
+                .ok_or_else(|| eyre!(format!("Unable to obtain file stem from {shell}")))?
+                .to_string_lossy()
+                .to_string();
+            match shell_bin_name.as_str() {
+                "bash" => ".bashrc",
+                "zsh" => ".zshrc",
+                _ => return Err(eyre!("shell {shell} is not supported by safeup")),
+            }
+        }
         Err(e) => return Err(eyre!(e)),
     };
     let home_dir_path =


### PR DESCRIPTION
We encountered a case where someone was using a Bash shell that was located at /usr/bin/local/bash, rather than the usual location at /bin/bash.

We now relax the check such that it only checks the binary file name.