### PR TITLE
chore: remove `testnet` command

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,7 +13,6 @@ env:
   CLIENT_VERSION: 0.77.27
   NODE_VERSION: 0.83.25
   NODE_MANAGER_VERSION: 0.1.8
-  TESTNET_VERSION: 0.1.29
 
 jobs:
   # The code in this crate uses lots of conditional compilation for cross-platform capabilities.
@@ -142,7 +141,6 @@ jobs:
           cargo run -- client --version $env:CLIENT_VERSION
           cargo run -- node --version $env:NODE_VERSION
           cargo run -- node-manager --version $env:NODE_MANAGER_VERSION
-          cargo run -- testnet --version $env:TESTNET_VERSION
       - name: Check if binaries are available in new shell session
         shell: pwsh
         run: |
@@ -156,10 +154,6 @@ jobs:
           }
           if (!(Test-Path "$env:USERPROFILE\safe\safenode-manager.exe")) {
             Write-Host "safenode-manager.exe does not exist"
-            exit 1
-          }
-          if (!(Test-Path "$env:USERPROFILE\safe\testnet.exe")) {
-            Write-Host "testnet.exe does not exist"
             exit 1
           }
 
@@ -203,18 +197,6 @@ jobs:
             exit 1
           }
 
-          $output = & "${env:USERPROFILE}\safe\testnet.exe" --version
-          $version = $output | Select-String -Pattern "testnet (\d+\.\d+\.\d+)"
-          $versionNumber = $version.Matches.Groups[1].Value
-          if ($versionNumber -eq "$env:TESTNET_VERSION") {
-            Write-Host "The correct version of testnet has been installed"
-          } else {
-            Write-Host "The correct version of testnet has not been installed"
-            Write-Host "We expected version $env:TESTNET_VERSION"
-            Write-Host "The downloaded binary has $versionNumber"
-            exit 1
-          }
-
   test-install-linux:
     if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"
     name: Install test (Linux)
@@ -232,7 +214,6 @@ jobs:
           cargo run -- client --version $CLIENT_VERSION
           cargo run -- node --version $NODE_VERSION
           cargo run -- node-manager --version $NODE_MANAGER_VERSION
-          cargo run -- testnet --version $TESTNET_VERSION
       - name: Check if binaries are available in new shell session
         shell: bash
         run: |
@@ -248,7 +229,6 @@ jobs:
           [[ -f "$HOME/.local/bin/safe" ]] || { echo "safe not in expected location"; exit 1; }
           [[ -f "$HOME/.local/bin/safenode" ]] || { echo "safenode not in expected location"; exit 1; }
           [[ -f "$HOME/.local/bin/safenode-manager" ]] || { echo "safenode-manager not in expected location"; exit 1; }
-          [[ -f "$HOME/.local/bin/testnet" ]] || { echo "testnet not in expected location"; exit 1; }
 
           version=$(safe --version | awk '{ print $2 }')
           if [[ "$version" == "$CLIENT_VERSION" ]]; then
@@ -276,16 +256,6 @@ jobs:
           else
             echo "The correct version of safenode-manager has not been installed"
             echo "We expected $NODE_MANAGER_VERSION"
-            echo "The downloaded binary has $version"
-            exit 1
-          fi
-
-          version=$(testnet --version | awk '{ print $2 }')
-          if [[ "$version" == "$TESTNET_VERSION" ]]; then
-            echo "The correct version of testnet has been installed"
-          else
-            echo "The correct version of testnet has not been installed"
-            echo "We expected $TESTNET_VERSION"
             echo "The downloaded binary has $version"
             exit 1
           fi
@@ -306,7 +276,6 @@ jobs:
           cargo run -- client --version $CLIENT_VERSION
           cargo run -- node --version $NODE_VERSION
           cargo run -- node-manager --version $NODE_MANAGER_VERSION
-          cargo run -- testnet --version $TESTNET_VERSION
       - name: Check if binaries are available in new shell session
         run: |
           # As with the Ubuntu test, we need to source the env file to get the binaries on PATH.
@@ -315,7 +284,6 @@ jobs:
           [[ -f "$HOME/.local/bin/safe" ]] || { echo "safe not in expected location"; exit 1; }
           [[ -f "$HOME/.local/bin/safenode" ]] || { echo "safenode not in expected location"; exit 1; }
           [[ -f "$HOME/.local/bin/safenode-manager" ]] || { echo "safenode-manager not in expected location"; exit 1; }
-          [[ -f "$HOME/.local/bin/testnet" ]] || { echo "testnet not in expected location"; exit 1; }
 
           version=$(safe --version | awk '{ print $2 }')
           if [[ "$version" == "$CLIENT_VERSION" ]]; then
@@ -343,16 +311,6 @@ jobs:
           else
             echo "The correct version of safenode-manager has not been installed"
             echo "We expected $NODE_MANAGER_VERSION"
-            echo "The downloaded binary has $version"
-            exit 1
-          fi
-
-          version=$(testnet --version | awk '{ print $2 }')
-          if [[ "$version" == "$TESTNET_VERSION" ]]; then
-            echo "The correct version of testnet has been installed"
-          else
-            echo "The correct version of testnet has not been installed"
-            echo "We expected $TESTNET_VERSION"
             echo "The downloaded binary has $version"
             exit 1
           fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ semver = "1.0.4"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-sn-releases = "0.1.5"
+sn-releases = "0.1.7"
 tempfile = "3.8.1"
 textwrap = "0.16.0"
 tokio = { version = "1.26", features = ["full"] }

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -30,8 +30,8 @@ lazy_static! {
             "https://sn-node.s3.eu-west-2.amazonaws.com",
         );
         m.insert(
-            AssetType::Testnet,
-            "https://sn-testnet.s3.eu-west-2.amazonaws.com",
+            AssetType::NodeManager,
+            "https://sn-node-manager.s3.eu-west-2.amazonaws.com",
         );
         m
     };
@@ -175,10 +175,6 @@ async fn do_install_binary(
         AssetType::NodeManager => {
             settings.safenode_manager_path = bin_path;
             settings.safenode_manager_version = installed_version;
-        }
-        AssetType::Testnet => {
-            settings.testnet_path = bin_path;
-            settings.testnet_version = installed_version;
         }
     }
     settings.save(&settings_file_path)?;

--- a/src/install.rs
+++ b/src/install.rs
@@ -50,17 +50,11 @@ pub enum AssetType {
     Client,
     Node,
     NodeManager,
-    Testnet,
 }
 
 impl AssetType {
     pub fn variants() -> Vec<AssetType> {
-        vec![
-            AssetType::Client,
-            AssetType::Node,
-            AssetType::NodeManager,
-            AssetType::Testnet,
-        ]
+        vec![AssetType::Client, AssetType::Node, AssetType::NodeManager]
     }
 
     pub fn get_release_type(&self) -> ReleaseType {
@@ -68,7 +62,6 @@ impl AssetType {
             AssetType::Client => ReleaseType::Safe,
             AssetType::Node => ReleaseType::Safenode,
             AssetType::NodeManager => ReleaseType::SafenodeManager,
-            AssetType::Testnet => ReleaseType::Testnet,
         }
     }
 }
@@ -79,7 +72,6 @@ impl std::fmt::Display for AssetType {
             AssetType::Client => write!(f, "safe"),
             AssetType::Node => write!(f, "safenode"),
             AssetType::NodeManager => write!(f, "safenode-manager"),
-            AssetType::Testnet => write!(f, "testnet"),
         }
     }
 }
@@ -92,8 +84,6 @@ pub struct Settings {
     pub safenode_version: String,
     pub safenode_manager_path: PathBuf,
     pub safenode_manager_version: String,
-    pub testnet_path: PathBuf,
-    pub testnet_version: String,
 }
 
 impl Settings {
@@ -108,8 +98,6 @@ impl Settings {
                 safenode_version: String::new(),
                 safenode_manager_path: PathBuf::new(),
                 safenode_manager_version: String::new(),
-                testnet_path: PathBuf::new(),
-                testnet_version: String::new(),
             })
         } else {
             Settings {
@@ -119,8 +107,6 @@ impl Settings {
                 safenode_version: String::new(),
                 safenode_manager_path: PathBuf::new(),
                 safenode_manager_version: String::new(),
-                testnet_path: PathBuf::new(),
-                testnet_version: String::new(),
             }
         };
         Ok(settings)
@@ -131,7 +117,6 @@ impl Settings {
             AssetType::Client => self.safe_version.clone(),
             AssetType::Node => self.safenode_version.clone(),
             AssetType::NodeManager => self.safenode_manager_version.clone(),
-            AssetType::Testnet => self.testnet_version.clone(),
         }
     }
 
@@ -140,7 +125,6 @@ impl Settings {
             AssetType::Client => !self.safe_version.is_empty(),
             AssetType::Node => !self.safenode_version.is_empty(),
             AssetType::NodeManager => !self.safenode_manager_version.is_empty(),
-            AssetType::Testnet => !self.testnet_version.is_empty(),
         }
     }
 
@@ -149,7 +133,6 @@ impl Settings {
             AssetType::Client => self.safe_path.clone(),
             AssetType::Node => self.safenode_path.clone(),
             AssetType::NodeManager => self.safenode_manager_path.clone(),
-            AssetType::Testnet => self.testnet_path.clone(),
         }
     }
 
@@ -359,7 +342,6 @@ fn get_bin_name(asset_type: &AssetType) -> String {
         AssetType::Client => "safe".to_string(),
         AssetType::Node => "safenode".to_string(),
         AssetType::NodeManager => "safenode-manager".to_string(),
-        AssetType::Testnet => "testnet".to_string(),
     };
     if OS == "windows" {
         bin_name.push_str(".exe");
@@ -733,8 +715,6 @@ mod test {
             safenode_version: "v0.75.2".to_string(),
             safenode_manager_path: safenode_manager_bin_file.to_path_buf(),
             safenode_manager_version: "v0.1.8".to_string(),
-            testnet_path: testnet_bin_file.to_path_buf(),
-            testnet_version: "v0.75.3".to_string(),
         };
 
         settings.save(&settings_file.to_path_buf())?;
@@ -750,8 +730,6 @@ mod test {
             safenode_manager_bin_file.to_path_buf()
         );
         assert_eq!(settings.safenode_manager_version, "v0.1.8");
-        assert_eq!(settings.testnet_path, testnet_bin_file.to_path_buf());
-        assert_eq!(settings.testnet_version, "v0.75.3");
         Ok(())
     }
 
@@ -780,8 +758,6 @@ mod test {
             safenode_version: "v0.75.2".to_string(),
             safenode_manager_path: safenode_manager_bin_file.to_path_buf(),
             safenode_manager_version: "v0.1.8".to_string(),
-            testnet_path: testnet_bin_file.to_path_buf(),
-            testnet_version: "v0.75.3".to_string(),
         };
 
         settings.save(&settings_file.to_path_buf())?;
@@ -797,8 +773,6 @@ mod test {
             safenode_manager_bin_file.to_path_buf()
         );
         assert_eq!(settings.safenode_manager_version, "v0.1.8");
-        assert_eq!(settings.testnet_path, testnet_bin_file.to_path_buf());
-        assert_eq!(settings.testnet_version, "v0.75.3");
         Ok(())
     }
 
@@ -814,9 +788,7 @@ mod test {
           "safenode_path": "/home/chris/.local/bin/safenode",
           "safenode_version": "v0.75.2",
           "safenode_manager_path": "/home/chris/.local/bin/safenode-manager",
-          "safenode_manager_version": "v0.1.8",
-          "testnet_path": "/home/chris/.local/bin/testnet",
-          "testnet_version": "v0.75.3"
+          "safenode_manager_version": "v0.1.8"
         }
         "#,
         )?;
@@ -840,11 +812,6 @@ mod test {
             PathBuf::from("/home/chris/.local/bin/safenode-manager")
         );
         assert_eq!(settings.safenode_manager_version, "v0.1.8");
-        assert_eq!(
-            settings.testnet_path,
-            PathBuf::from("/home/chris/.local/bin/testnet")
-        );
-        assert_eq!(settings.testnet_version, "v0.75.3");
         Ok(())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,30 +101,6 @@ enum Commands {
         #[arg(short = 'v', long)]
         version: Option<String>,
     },
-    /// Install the testnet binary.
-    ///
-    /// The location is platform specific:
-    /// - Linux/macOS: $HOME/.local/bin
-    /// - Windows: C:\Users\<username>\safe
-    ///
-    /// On Linux/macOS, the Bash shell profile will be modified to add $HOME/.local/bin to the PATH
-    /// variable. On Windows, the user Path variable will be modified to add C:\Users\<username>\safe.
-    #[clap(verbatim_doc_comment)]
-    Testnet {
-        /// Override the default installation path.
-        ///
-        /// Any directories that don't exist will be created.
-        #[arg(short = 'p', long, value_name = "DIRECTORY")]
-        path: Option<PathBuf>,
-
-        /// Disable modification of the shell profile.
-        #[arg(short = 'n', long)]
-        no_modify_shell_profile: bool,
-
-        /// Install a specific version rather than the latest.
-        #[arg(short = 'v', long)]
-        version: Option<String>,
-    },
     /// Update installed components.
     #[clap(verbatim_doc_comment)]
     Update {},
@@ -181,19 +157,6 @@ async fn main() -> Result<()> {
                 no_modify_shell_profile,
             )
             .await
-        }
-        Some(Commands::Testnet {
-            path,
-            no_modify_shell_profile,
-            version,
-        }) => {
-            println!("**************************************");
-            println!("*                                    *");
-            println!("*          Installing testnet        *");
-            println!("*                                    *");
-            println!("**************************************");
-            install::check_prerequisites()?;
-            process_install_cmd(AssetType::Testnet, path, version, no_modify_shell_profile).await
         }
         Some(Commands::Update {}) => {
             println!("**************************************");

--- a/src/update.rs
+++ b/src/update.rs
@@ -58,8 +58,6 @@ mod test {
             safenode_version: "v0.83.13".to_string(),
             safenode_manager_path: PathBuf::from("/home/chris/.local/bin/safenode-manager"),
             safenode_manager_version: "v0.1.8".to_string(),
-            testnet_path: PathBuf::from("/home/chris/.local/bin/testnet"),
-            testnet_version: "v0.3.4".to_string(),
         };
         let decision = perform_update_assessment(&AssetType::Client, "v0.78.26", &settings)?;
         assert_matches!(decision, UpdateAssessmentResult::NoPreviousInstallation);
@@ -71,8 +69,6 @@ mod test {
             safenode_version: String::new(),
             safenode_manager_path: PathBuf::from("/home/chris/.local/bin/safenode-manager"),
             safenode_manager_version: "v0.1.8".to_string(),
-            testnet_path: PathBuf::from("/home/chris/.local/bin/testnet"),
-            testnet_version: "v0.3.4".to_string(),
         };
         let decision = perform_update_assessment(&AssetType::Node, "v0.83.13", &settings)?;
         assert_matches!(decision, UpdateAssessmentResult::NoPreviousInstallation);
@@ -84,23 +80,8 @@ mod test {
             safenode_version: "v0.83.13".to_string(),
             safenode_manager_path: PathBuf::new(),
             safenode_manager_version: String::new(),
-            testnet_path: PathBuf::from("/home/chris/.local/bin/testnet"),
-            testnet_version: "v0.3.4".to_string(),
         };
         let decision = perform_update_assessment(&AssetType::NodeManager, "v0.1.8", &settings)?;
-        assert_matches!(decision, UpdateAssessmentResult::NoPreviousInstallation);
-
-        let settings = Settings {
-            safe_path: PathBuf::from("/home/chris/.local/safe"),
-            safe_version: "v0.78.26".to_string(),
-            safenode_path: PathBuf::from("/home/chris/.local/bin/safenode"),
-            safenode_version: "v0.83.13".to_string(),
-            safenode_manager_path: PathBuf::from("/home/chris/.local/bin/safenode-manager"),
-            safenode_manager_version: "v0.1.8".to_string(),
-            testnet_path: PathBuf::new(),
-            testnet_version: String::new(),
-        };
-        let decision = perform_update_assessment(&AssetType::Testnet, "v0.3.4", &settings)?;
         assert_matches!(decision, UpdateAssessmentResult::NoPreviousInstallation);
 
         Ok(())
@@ -115,8 +96,6 @@ mod test {
             safenode_version: "v0.83.13".to_string(),
             safenode_manager_path: PathBuf::from("/home/chris/.local/bin/safenode-manager"),
             safenode_manager_version: "v0.1.8".to_string(),
-            testnet_path: PathBuf::from("/home/chris/.local/bin/testnet"),
-            testnet_version: "v0.3.4".to_string(),
         };
 
         let decision = perform_update_assessment(&AssetType::Client, "v0.78.26", &settings)?;
@@ -126,9 +105,6 @@ mod test {
         assert_matches!(decision, UpdateAssessmentResult::AtLatestVersion);
 
         let decision = perform_update_assessment(&AssetType::NodeManager, "v0.1.8", &settings)?;
-        assert_matches!(decision, UpdateAssessmentResult::AtLatestVersion);
-
-        let decision = perform_update_assessment(&AssetType::Testnet, "v0.3.4", &settings)?;
         assert_matches!(decision, UpdateAssessmentResult::AtLatestVersion);
 
         Ok(())
@@ -144,8 +120,6 @@ mod test {
             safenode_version: "v0.83.13".to_string(),
             safenode_manager_path: PathBuf::from("/home/chris/.local/bin/safenode-manager"),
             safenode_manager_version: "v0.1.8".to_string(),
-            testnet_path: PathBuf::from("/home/chris/.local/bin/testnet"),
-            testnet_version: "v0.3.4".to_string(),
         };
 
         let result = perform_update_assessment(&AssetType::Client, "v0.76.0", &settings);
@@ -196,8 +170,6 @@ mod test {
             safenode_version: "v0.83.13".to_string(),
             safenode_manager_path: PathBuf::from("/home/chris/.local/bin/safenode-manager"),
             safenode_manager_version: "v0.1.7".to_string(),
-            testnet_path: PathBuf::from("/home/chris/.local/bin/testnet"),
-            testnet_version: "v0.3.4".to_string(),
         };
 
         let decision = perform_update_assessment(&AssetType::Client, "v0.78.27", &settings)?;
@@ -207,9 +179,6 @@ mod test {
         assert_matches!(decision, UpdateAssessmentResult::PerformUpdate);
 
         let decision = perform_update_assessment(&AssetType::NodeManager, "v0.1.8", &settings)?;
-        assert_matches!(decision, UpdateAssessmentResult::PerformUpdate);
-
-        let decision = perform_update_assessment(&AssetType::Testnet, "v0.3.5", &settings)?;
         assert_matches!(decision, UpdateAssessmentResult::PerformUpdate);
 
         Ok(())
@@ -225,8 +194,6 @@ mod test {
             safenode_version: "v0.83.13".to_string(),
             safenode_manager_path: PathBuf::from("/home/chris/.local/bin/safenode-manager"),
             safenode_manager_version: "v0.1.7".to_string(),
-            testnet_path: PathBuf::from("/home/chris/.local/bin/testnet"),
-            testnet_version: "v0.3.4".to_string(),
         };
 
         let decision = perform_update_assessment(&AssetType::Client, "v0.79.0", &settings)?;
@@ -236,9 +203,6 @@ mod test {
         assert_matches!(decision, UpdateAssessmentResult::PerformUpdate);
 
         let decision = perform_update_assessment(&AssetType::NodeManager, "v0.2.0", &settings)?;
-        assert_matches!(decision, UpdateAssessmentResult::PerformUpdate);
-
-        let decision = perform_update_assessment(&AssetType::Testnet, "v0.4.0", &settings)?;
         assert_matches!(decision, UpdateAssessmentResult::PerformUpdate);
 
         Ok(())
@@ -254,8 +218,6 @@ mod test {
             safenode_version: "v0.83.13".to_string(),
             safenode_manager_path: PathBuf::from("/home/chris/.local/bin/safenode-manager"),
             safenode_manager_version: "v0.1.7".to_string(),
-            testnet_path: PathBuf::from("/home/chris/.local/bin/testnet"),
-            testnet_version: "v0.3.4".to_string(),
         };
 
         let decision = perform_update_assessment(&AssetType::Client, "v1.0.0", &settings)?;
@@ -265,9 +227,6 @@ mod test {
         assert_matches!(decision, UpdateAssessmentResult::PerformUpdate);
 
         let decision = perform_update_assessment(&AssetType::NodeManager, "v1.0.0", &settings)?;
-        assert_matches!(decision, UpdateAssessmentResult::PerformUpdate);
-
-        let decision = perform_update_assessment(&AssetType::Testnet, "v1.0.0", &settings)?;
         assert_matches!(decision, UpdateAssessmentResult::PerformUpdate);
 
         Ok(())
@@ -282,8 +241,6 @@ mod test {
             safenode_version: "0.83.13".to_string(),
             safenode_manager_path: PathBuf::from("/home/chris/.local/bin/safenode-manager"),
             safenode_manager_version: "v0.1.7".to_string(),
-            testnet_path: PathBuf::from("/home/chris/.local/bin/testnet"),
-            testnet_version: "0.3.4".to_string(),
         };
 
         let decision = perform_update_assessment(&AssetType::Client, "0.78.27", &settings)?;


### PR DESCRIPTION
We have removed support for the `testnet` binary, so it no longer applies and is hence being removed.

Also upgrades `sn-releases` to the latest version, which uses the crates.io API to get the latest version of a crate.

BREAKING CHANGE: properties have been removed from the `Settings` struct, meaning settings files from previous versions will be incompatible with this new version.