### PR TITLE
refactor: use version type rather than strings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ semver = "1.0.4"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-sn-releases = "0.1.7"
+sn-releases = "0.2.0"
 tempfile = "3.8.1"
 textwrap = "0.16.0"
 tokio = { version = "1.26", features = ["full"] }


### PR DESCRIPTION
Upgrade to `sn-releases` version 0.2.0, which forces the use of the `semver::Version` type rather than `String` for dealing with versions.

It made sense to do the same thing with string-based version fields in this crate. All of the fields on the `Settings` type were also turned into an `Option`, which makes sense because it's possible that we don't have one of the asset types installed. I'm not sure why this wasn't done in the first place. It made the code a bit simpler.

BREAKING CHANGE: settings files from previous versions will not deserialize properly and will have to be deleted.