### PR TITLE
feat: provide `node-launchpad` command

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,6 +13,7 @@ env:
   CLIENT_VERSION: 0.77.27
   NODE_VERSION: 0.83.25
   NODE_MANAGER_VERSION: 0.1.8
+  NODE_LAUNCHPAD_VERSION: 0.2.0
 
 jobs:
   # The code in this crate uses lots of conditional compilation for cross-platform capabilities.
@@ -141,6 +142,7 @@ jobs:
           cargo run -- client --version $env:CLIENT_VERSION
           cargo run -- node --version $env:NODE_VERSION
           cargo run -- node-manager --version $env:NODE_MANAGER_VERSION
+          cargo run -- node-launchpad --version $env:NODE_LAUNCHPAD_VERSION
       - name: Check if binaries are available in new shell session
         shell: pwsh
         run: |
@@ -154,6 +156,10 @@ jobs:
           }
           if (!(Test-Path "$env:USERPROFILE\safe\safenode-manager.exe")) {
             Write-Host "safenode-manager.exe does not exist"
+            exit 1
+          }
+          if (!(Test-Path "$env:USERPROFILE\safe\node-launchpad.exe")) {
+            Write-Host "node-launchpad.exe does not exist"
             exit 1
           }
 
@@ -197,6 +203,18 @@ jobs:
             exit 1
           }
 
+          $output = & "${env:USERPROFILE}\safe\node-launchpad.exe" --version
+          $version = $output | Select-String -Pattern "node-launchpad (\d+\.\d+\.\d+)"
+          $versionNumber = $version.Matches.Groups[1].Value
+          if ($versionNumber -eq "$env:NODE_LAUNCHPAD_VERSION") {
+            Write-Host "The correct version of safenode-manager has been installed"
+          } else {
+            Write-Host "The correct version of safenode-manager has not been installed"
+            Write-Host "We expected version $env:NODE_LAUNCHPAD_VERSION"
+            Write-Host "The downloaded binary has $versionNumber"
+            exit 1
+          }
+
   test-install-linux:
     if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"
     name: Install test (Linux)
@@ -214,6 +232,7 @@ jobs:
           cargo run -- client --version $CLIENT_VERSION
           cargo run -- node --version $NODE_VERSION
           cargo run -- node-manager --version $NODE_MANAGER_VERSION
+          cargo run -- node-launchpad --version $NODE_LAUNCHPAD_VERSION
       - name: Check if binaries are available in new shell session
         shell: bash
         run: |
@@ -229,6 +248,7 @@ jobs:
           [[ -f "$HOME/.local/bin/safe" ]] || { echo "safe not in expected location"; exit 1; }
           [[ -f "$HOME/.local/bin/safenode" ]] || { echo "safenode not in expected location"; exit 1; }
           [[ -f "$HOME/.local/bin/safenode-manager" ]] || { echo "safenode-manager not in expected location"; exit 1; }
+          [[ -f "$HOME/.local/bin/node-launchpad" ]] || { echo "node-launchpad not in expected location"; exit 1; }
 
           version=$(safe --version | awk '{ print $2 }')
           if [[ "$version" == "$CLIENT_VERSION" ]]; then
@@ -256,6 +276,16 @@ jobs:
           else
             echo "The correct version of safenode-manager has not been installed"
             echo "We expected $NODE_MANAGER_VERSION"
+            echo "The downloaded binary has $version"
+            exit 1
+          fi
+
+          version=$(node-launchpad --version | awk '{ print $2 }')
+          if [[ "$version" == "$NODE_LAUNCHPAD_VERSION" ]]; then
+            echo "The correct version of node-launchpad has been installed"
+          else
+            echo "The correct version of node-launchpad has not been installed"
+            echo "We expected $NODE_LAUNCHPAD_VERSION"
             echo "The downloaded binary has $version"
             exit 1
           fi
@@ -276,6 +306,7 @@ jobs:
           cargo run -- client --version $CLIENT_VERSION
           cargo run -- node --version $NODE_VERSION
           cargo run -- node-manager --version $NODE_MANAGER_VERSION
+          cargo run -- node-launchpad --version $NODE_LAUNCHPAD_VERSION
       - name: Check if binaries are available in new shell session
         run: |
           # As with the Ubuntu test, we need to source the env file to get the binaries on PATH.
@@ -284,6 +315,7 @@ jobs:
           [[ -f "$HOME/.local/bin/safe" ]] || { echo "safe not in expected location"; exit 1; }
           [[ -f "$HOME/.local/bin/safenode" ]] || { echo "safenode not in expected location"; exit 1; }
           [[ -f "$HOME/.local/bin/safenode-manager" ]] || { echo "safenode-manager not in expected location"; exit 1; }
+          [[ -f "$HOME/.local/bin/node-launchpad" ]] || { echo "node-launchpad not in expected location"; exit 1; }
 
           version=$(safe --version | awk '{ print $2 }')
           if [[ "$version" == "$CLIENT_VERSION" ]]; then
@@ -311,6 +343,16 @@ jobs:
           else
             echo "The correct version of safenode-manager has not been installed"
             echo "We expected $NODE_MANAGER_VERSION"
+            echo "The downloaded binary has $version"
+            exit 1
+          fi
+
+          version=$(node-launchpad --version | awk '{ print $2 }')
+          if [[ "$version" == "$NODE_LAUNCHPAD_VERSION" ]]; then
+            echo "The correct version of node-launchpad has been installed"
+          else
+            echo "The correct version of node-launchpad has not been installed"
+            echo "We expected $NODE_LAUNCHPAD_VERSION"
             echo "The downloaded binary has $version"
             exit 1
           fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ semver = "1.0.4"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-sn-releases = "0.2.0"
+sn-releases = "0.2.5"
 tempfile = "3.8.1"
 textwrap = "0.16.0"
 tokio = { version = "1.26", features = ["full"] }

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -173,6 +173,10 @@ async fn do_install_binary(
             settings.safenode_path = Some(bin_path);
             settings.safenode_version = Some(installed_version);
         }
+        AssetType::NodeLaunchpad => {
+            settings.node_launchpad_path = Some(bin_path);
+            settings.node_launchpad_version = Some(installed_version);
+        }
         AssetType::NodeManager => {
             settings.safenode_manager_path = Some(bin_path);
             settings.safenode_manager_version = Some(installed_version);

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,6 +77,30 @@ enum Commands {
         #[arg(short = 'v', long)]
         version: Option<String>,
     },
+    /// Install the node-launchpad binary.
+    ///
+    /// The location is platform specific:
+    /// - Linux/macOS: $HOME/.local/bin
+    /// - Windows: C:\Users\<username>\safe
+    ///
+    /// On Linux/macOS, the Bash shell profile will be modified to add $HOME/.local/bin to the PATH
+    /// variable. On Windows, the user Path variable will be modified to add C:\Users\<username>\safe.
+    #[clap(verbatim_doc_comment)]
+    NodeLaunchpad {
+        /// Override the default installation path.
+        ///
+        /// Any directories that don't exist will be created.
+        #[arg(short = 'p', long, value_name = "DIRECTORY")]
+        path: Option<PathBuf>,
+
+        /// Disable modification of the shell profile.
+        #[arg(short = 'n', long)]
+        no_modify_shell_profile: bool,
+
+        /// Install a specific version rather than the latest.
+        #[arg(short = 'v', long)]
+        version: Option<String>,
+    },
     /// Install the safenode-manager binary.
     ///
     /// The location is platform specific:
@@ -138,6 +162,25 @@ async fn main() -> Result<()> {
             println!("**************************************");
             install::check_prerequisites()?;
             process_install_cmd(AssetType::Node, path, version, no_modify_shell_profile).await
+        }
+        Some(Commands::NodeLaunchpad {
+            path,
+            no_modify_shell_profile,
+            version,
+        }) => {
+            println!("**************************************");
+            println!("*                                    *");
+            println!("*     Installing node-launchpad      *");
+            println!("*                                    *");
+            println!("**************************************");
+            install::check_prerequisites()?;
+            process_install_cmd(
+                AssetType::NodeLaunchpad,
+                path,
+                version,
+                no_modify_shell_profile,
+            )
+            .await
         }
         Some(Commands::NodeManager {
             path,

--- a/src/update.rs
+++ b/src/update.rs
@@ -51,6 +51,8 @@ mod test {
     #[test]
     fn perform_upgrade_assessment_should_indicate_no_previous_installation() -> Result<()> {
         let settings = Settings {
+            node_launchpad_path: Some(PathBuf::from("/home/chris/.local/bin/node-launchpad")),
+            node_launchpad_version: Some(Version::new(0, 2, 0)),
             safe_path: None,
             safe_version: None,
             safenode_path: Some(PathBuf::from("/home/chris/.local/bin/safenode")),
@@ -63,6 +65,8 @@ mod test {
         assert_matches!(decision, UpdateAssessmentResult::NoPreviousInstallation);
 
         let settings = Settings {
+            node_launchpad_path: Some(PathBuf::from("/home/chris/.local/bin/node-launchpad")),
+            node_launchpad_version: Some(Version::new(0, 2, 0)),
             safe_path: Some(PathBuf::from("/home/chris/.local/safe")),
             safe_version: Some(Version::new(0, 78, 26)),
             safenode_path: None,
@@ -75,6 +79,8 @@ mod test {
         assert_matches!(decision, UpdateAssessmentResult::NoPreviousInstallation);
 
         let settings = Settings {
+            node_launchpad_path: Some(PathBuf::from("/home/chris/.local/bin/node-launchpad")),
+            node_launchpad_version: Some(Version::new(0, 2, 0)),
             safe_path: Some(PathBuf::from("/home/chris/.local/safe")),
             safe_version: Some(Version::new(0, 78, 26)),
             safenode_path: Some(PathBuf::from("/home/chris/.local/bin/safenode")),
@@ -86,12 +92,31 @@ mod test {
             perform_update_assessment(&AssetType::NodeManager, &Version::new(0, 1, 8), &settings)?;
         assert_matches!(decision, UpdateAssessmentResult::NoPreviousInstallation);
 
+        let settings = Settings {
+            node_launchpad_path: None,
+            node_launchpad_version: None,
+            safe_path: Some(PathBuf::from("/home/chris/.local/safe")),
+            safe_version: Some(Version::new(0, 78, 26)),
+            safenode_path: Some(PathBuf::from("/home/chris/.local/bin/safenode")),
+            safenode_version: Some(Version::new(0, 83, 13)),
+            safenode_manager_path: Some(PathBuf::from("/home/chris/.local/bin/safenode-manager")),
+            safenode_manager_version: Some(Version::new(0, 1, 8)),
+        };
+        let decision = perform_update_assessment(
+            &AssetType::NodeLaunchpad,
+            &Version::new(0, 2, 0),
+            &settings,
+        )?;
+        assert_matches!(decision, UpdateAssessmentResult::NoPreviousInstallation);
+
         Ok(())
     }
 
     #[test]
     fn perform_upgrade_assessment_should_indicate_we_are_at_latest_version() -> Result<()> {
         let settings = Settings {
+            node_launchpad_path: Some(PathBuf::from("/home/chris/.local/node-launchpad")),
+            node_launchpad_version: Some(Version::new(0, 2, 0)),
             safe_path: Some(PathBuf::from("/home/chris/.local/safe")),
             safe_version: Some(Version::new(0, 78, 26)),
             safenode_path: Some(PathBuf::from("/home/chris/.local/bin/safenode")),
@@ -112,6 +137,13 @@ mod test {
             perform_update_assessment(&AssetType::NodeManager, &Version::new(0, 1, 8), &settings)?;
         assert_matches!(decision, UpdateAssessmentResult::AtLatestVersion);
 
+        let decision = perform_update_assessment(
+            &AssetType::NodeLaunchpad,
+            &Version::new(0, 2, 0),
+            &settings,
+        )?;
+        assert_matches!(decision, UpdateAssessmentResult::AtLatestVersion);
+
         Ok(())
     }
 
@@ -119,6 +151,8 @@ mod test {
     fn perform_upgrade_assessment_latest_version_is_less_than_current_should_return_error(
     ) -> Result<()> {
         let settings = Settings {
+            node_launchpad_path: Some(PathBuf::from("/home/chris/.local/node-launchpad")),
+            node_launchpad_version: Some(Version::new(0, 2, 0)),
             safe_path: Some(PathBuf::from("/home/chris/.local/safe")),
             safe_version: Some(Version::new(0, 78, 26)),
             safenode_path: Some(PathBuf::from("/home/chris/.local/bin/safenode")),
@@ -157,6 +191,16 @@ mod test {
             ),
         }
 
+        let result =
+            perform_update_assessment(&AssetType::NodeLaunchpad, &Version::new(0, 1, 0), &settings);
+        match result {
+            Ok(_) => return Err(eyre!("this test should return an error")),
+            Err(e) => assert_eq!(
+                "The latest version is less than the current version of your binary.",
+                e.to_string()
+            ),
+        }
+
         Ok(())
     }
 
@@ -164,6 +208,8 @@ mod test {
     fn perform_upgrade_assessment_should_perform_update_when_latest_patch_version_is_greater(
     ) -> Result<()> {
         let settings = Settings {
+            node_launchpad_path: Some(PathBuf::from("/home/chris/.local/node-launchpad")),
+            node_launchpad_version: Some(Version::new(0, 2, 0)),
             safe_path: Some(PathBuf::from("/home/chris/.local/safe")),
             safe_version: Some(Version::new(0, 78, 26)),
             safenode_path: Some(PathBuf::from("/home/chris/.local/bin/safenode")),
@@ -184,6 +230,13 @@ mod test {
             perform_update_assessment(&AssetType::NodeManager, &Version::new(0, 1, 8), &settings)?;
         assert_matches!(decision, UpdateAssessmentResult::PerformUpdate(_));
 
+        let decision = perform_update_assessment(
+            &AssetType::NodeLaunchpad,
+            &Version::new(0, 2, 1),
+            &settings,
+        )?;
+        assert_matches!(decision, UpdateAssessmentResult::PerformUpdate(_));
+
         Ok(())
     }
 
@@ -191,6 +244,8 @@ mod test {
     fn perform_upgrade_assessment_should_perform_update_when_latest_minor_version_is_greater(
     ) -> Result<()> {
         let settings = Settings {
+            node_launchpad_path: Some(PathBuf::from("/home/chris/.local/node-launchpad")),
+            node_launchpad_version: Some(Version::new(0, 2, 0)),
             safe_path: Some(PathBuf::from("/home/chris/.local/safe")),
             safe_version: Some(Version::new(0, 78, 26)),
             safenode_path: Some(PathBuf::from("/home/chris/.local/bin/safenode")),
@@ -211,6 +266,13 @@ mod test {
             perform_update_assessment(&AssetType::NodeManager, &Version::new(0, 2, 0), &settings)?;
         assert_matches!(decision, UpdateAssessmentResult::PerformUpdate(_));
 
+        let decision = perform_update_assessment(
+            &AssetType::NodeLaunchpad,
+            &Version::new(0, 3, 0),
+            &settings,
+        )?;
+        assert_matches!(decision, UpdateAssessmentResult::PerformUpdate(_));
+
         Ok(())
     }
 
@@ -218,6 +280,8 @@ mod test {
     fn perform_upgrade_assessment_should_perform_update_when_latest_major_version_is_greater(
     ) -> Result<()> {
         let settings = Settings {
+            node_launchpad_path: Some(PathBuf::from("/home/chris/.local/node-launchpad")),
+            node_launchpad_version: Some(Version::new(0, 2, 0)),
             safe_path: Some(PathBuf::from("/home/chris/.local/safe")),
             safe_version: Some(Version::new(0, 78, 26)),
             safenode_path: Some(PathBuf::from("/home/chris/.local/bin/safenode")),
@@ -236,6 +300,13 @@ mod test {
 
         let decision =
             perform_update_assessment(&AssetType::NodeManager, &Version::new(1, 0, 0), &settings)?;
+        assert_matches!(decision, UpdateAssessmentResult::PerformUpdate(_));
+
+        let decision = perform_update_assessment(
+            &AssetType::NodeLaunchpad,
+            &Version::new(1, 0, 0),
+            &settings,
+        )?;
         assert_matches!(decision, UpdateAssessmentResult::PerformUpdate(_));
 
         Ok(())


### PR DESCRIPTION
BREAKING CHANGE: the new settings file will have additional entries for keeping track of the node-launchpad installation. Previously serialised settings files will be incompatible with this change. Users will need to clear their previous settings file when they upgrade.