### PR TITLE
feat: `client` cmd now uses the `autonomi` binary

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,9 +10,9 @@ on: pull_request
 env:
   RUST_BACKTRACE: 1
   RUSTFLAGS: "-D warnings"
-  CLIENT_VERSION: 0.94.0
-  NODE_VERSION: 0.110.0
-  NODE_MANAGER_VERSION: 0.10.1
+  CLIENT_VERSION: 0.1.1-rc.1
+  NODE_VERSION: 0.112.0-rc.1
+  NODE_MANAGER_VERSION: 0.11.0-rc.1
 
 jobs:
   # The code in this crate uses lots of conditional compilation for cross-platform capabilities.
@@ -146,15 +146,15 @@ jobs:
       - name: Check if binaries are available in new shell session
         shell: pwsh
         run: |
-          if (!(Test-Path "$env:USERPROFILE\safe\safe.exe")) {
-            Write-Host "safe.exe does not exist"
+          if (!(Test-Path "$env:USERPROFILE\autonomi\autonomi.exe")) {
+            Write-Host "autonomi.exe does not exist"
             exit 1
           }
-          if (!(Test-Path "$env:USERPROFILE\safe\safenode.exe")) {
+          if (!(Test-Path "$env:USERPROFILE\autonomi\safenode.exe")) {
             Write-Host "safenode.exe does not exist"
             exit 1
           }
-          if (!(Test-Path "$env:USERPROFILE\safe\safenode-manager.exe")) {
+          if (!(Test-Path "$env:USERPROFILE\autonomi\safenode-manager.exe")) {
             Write-Host "safenode-manager.exe does not exist"
             exit 1
           }
@@ -163,21 +163,21 @@ jobs:
           # being modified easily, so we need to refer to the binaries with their full paths.
           # Other manual testing has proven that the changes to the Path environment variable do
           # take effect.
-          $output = & "${env:USERPROFILE}\safe\safe.exe" --version
-          $version = $output | Select-String -Pattern "sn_cli (\d+\.\d+\.\d+)"
+          $output = & "${env:USERPROFILE}\autonomi\autonomi.exe" --version
+          $version = $output | Select-String -Pattern "autonomi-cli (\d+\.\d+\.\d+(?:-[a-zA-Z0-9]+(?:\.[0-9]+)?)?)"
           $versionNumber = $version.Matches.Groups[1].Value
           if ($versionNumber -eq "$env:CLIENT_VERSION") {
-            Write-Host "The correct version of safe has been installed"
+            Write-Host "The correct version of autonomi has been installed"
           } else {
-            Write-Host "The correct version of safe has not been installed"
+            Write-Host "The correct version of autonomi has not been installed"
           Write-Host "We expected version $env:CLIENT_VERSION"
             Write-Host "The downloaded binary has $versionNumber"
             exit 1
           }
 
-          $output = & "${env:USERPROFILE}\safe\safenode.exe" --version
-          $version = $output | Select-String -Pattern "safenode cli (\d+\.\d+\.\d+)"
-          $versionNumber = $version.Matches.Groups[1].Value
+          $output = & "${env:USERPROFILE}\autonomi\safenode.exe" --version
+          $version = $output -split "`n" | Select-Object -First 1
+          $versionNumber = ($version -split "v")[1].Trim()
           if ($versionNumber -eq "$env:NODE_VERSION") {
             Write-Host "The correct version of safenode has been installed"
           } else {
@@ -187,9 +187,9 @@ jobs:
             exit 1
           }
 
-          $output = & "${env:USERPROFILE}\safe\safenode-manager.exe" --version
-          $version = $output | Select-String -Pattern "sn-node-manager (\d+\.\d+\.\d+)"
-          $versionNumber = $version.Matches.Groups[1].Value
+          $output = & "${env:USERPROFILE}\autonomi\safenode-manager.exe" --version
+          $version = $output -split "`n" | Select-Object -First 1
+          $versionNumber = ($version -split "v")[1].Trim()
           if ($versionNumber -eq "$env:NODE_MANAGER_VERSION") {
             Write-Host "The correct version of safenode-manager has been installed"
           } else {
@@ -226,23 +226,23 @@ jobs:
           # the test does prove that the env file modifies PATH correctly and
           # that the installs of the binaries are available from their local
           # locations.
-          source ~/.config/safe/env
+          source ~/.config/autonomi/env
 
-          [[ -f "$HOME/.local/bin/safe" ]] || { echo "safe not in expected location"; exit 1; }
+          [[ -f "$HOME/.local/bin/autonomi" ]] || { echo "autonomi not in expected location"; exit 1; }
           [[ -f "$HOME/.local/bin/safenode" ]] || { echo "safenode not in expected location"; exit 1; }
           [[ -f "$HOME/.local/bin/safenode-manager" ]] || { echo "safenode-manager not in expected location"; exit 1; }
 
-          version=$(safe --version | awk '{ print $2 }')
+          version=$(autonomi --version | awk '{ print $2 }')
           if [[ "$version" == "$CLIENT_VERSION" ]]; then
-            echo "The correct version of safe has been installed"
+            echo "The correct version of autonomi has been installed"
           else
-            echo "The correct version of safe has not been installed"
+            echo "The correct version of autonomi has not been installed"
             echo "We expected $CLIENT_VERSION"
             echo "The downloaded binary has $version"
             exit 1
           fi
 
-          version=$(safenode --version | awk '{ print $3 }')
+          version=$(safenode --version | head -n 1 | awk '{print $3}' | sed 's/^v//')
           if [[ "$version" == "$NODE_VERSION" ]]; then
             echo "The correct version of safenode has been installed"
           else
@@ -252,7 +252,7 @@ jobs:
             exit 1
           fi
 
-          version=$(safenode-manager --version | awk '{ print $2 }')
+          version=$(safenode-manager --version | head -n 1 | awk '{print $4}' | sed 's/^v//')
           if [[ "$version" == "$NODE_MANAGER_VERSION" ]]; then
             echo "The correct version of safenode-manager has been installed"
           else
@@ -281,23 +281,23 @@ jobs:
       - name: Check if binaries are available in new shell session
         run: |
           # As with the Ubuntu test, we need to source the env file to get the binaries on PATH.
-          source "/Users/runner/Library/Application Support/safe/env"
+          source "/Users/runner/Library/Application Support/autonomi/env"
 
-          [[ -f "$HOME/.local/bin/safe" ]] || { echo "safe not in expected location"; exit 1; }
+          [[ -f "$HOME/.local/bin/autonomi" ]] || { echo "autonomi not in expected location"; exit 1; }
           [[ -f "$HOME/.local/bin/safenode" ]] || { echo "safenode not in expected location"; exit 1; }
           [[ -f "$HOME/.local/bin/safenode-manager" ]] || { echo "safenode-manager not in expected location"; exit 1; }
 
-          version=$(safe --version | awk '{ print $2 }')
+          version=$(autonomi --version | awk '{ print $2 }')
           if [[ "$version" == "$CLIENT_VERSION" ]]; then
-            echo "The correct version of safe has been installed"
+            echo "The correct version of autonomi has been installed"
           else
-            echo "The correct version of safe has not been installed"
+            echo "The correct version of autonomi has not been installed"
             echo "We expected $CLIENT_VERSION"
             echo "The downloaded binary has $version"
             exit 1
           fi
 
-          version=$(safenode --version | awk '{ print $3 }')
+          version=$(safenode --version | head -n 1 | awk '{print $3}' | sed 's/^v//')
           if [[ "$version" == "$NODE_VERSION" ]]; then
             echo "The correct version of safenode has been installed"
           else
@@ -307,7 +307,7 @@ jobs:
             exit 1
           fi
 
-          version=$(safenode-manager --version | awk '{ print $2 }')
+          version=$(safenode-manager --version | head -n 1 | awk '{print $4}' | sed 's/^v//')
           if [[ "$version" == "$NODE_MANAGER_VERSION" ]]; then
             echo "The correct version of safenode-manager has been installed"
           else
@@ -331,3 +331,4 @@ jobs:
 
       - name: dry run publish
         run: cargo publish --dry-run
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ semver = "1.0.4"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-sn-releases = "0.2.7"
+sn-releases = "0.3.0"
 tempfile = "3.8.1"
 textwrap = "0.16.0"
 tokio = { version = "1.26", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Otherwise:
 curl -sSL https://raw.githubusercontent.com/maidsafe/safeup/main/install.sh | bash
 ```
 
-This process will download and install `safeup` for your platform, then run it to have it install the `safe` client binary.
+This process will download and install `safeup` for your platform.
 
-The install script also accepts two flag arguments, namely `--client` and `--node`. If either are used, the script will invoke the installed `safeup` binary to install `safe` and `safenode`, respectively, without having to run either as an additional post-install step.
+The install script also accepts two flag arguments, namely `--client` and `--node`. If either are used, the script will invoke the installed `safeup` binary to install `autonomi` and `safenode`, respectively, without having to run either as an additional post-install step.
 
 To use these options as `sudo`:
 ```
@@ -45,7 +45,7 @@ Therefore, installing any components on Windows is an additional post-safeup-ins
 
 ## Usage
 
-Use the `client`, `node` or `testnet` commands to install the latest versions of the `safe`, `safenode` or `testnet` binaries, respectively. 
+Use the `client`, `node` or `testnet` commands to install the latest versions of the `autonomi`, `safenode` or `testnet` binaries, respectively. 
 
 As above, you can choose to run `safeup` using `sudo`, depending on where you'd like your binaries installed. Again, this does not apply to Windows, where we don't support running with Administrator privileges.
 

--- a/install.ps1
+++ b/install.ps1
@@ -18,19 +18,19 @@ $downloadUrl = $asset.browser_download_url
 $archivePath = Join-Path $env:TEMP "safeup.zip"
 Invoke-WebRequest -Uri $downloadUrl -OutFile $archivePath
 
-$safePath = Join-Path $env:USERPROFILE "safe"
-New-Item -ItemType Directory -Force -Path $safePath
-Expand-Archive -Path $archivePath -DestinationPath $safePath -Force
+$autonomiPath = Join-Path $env:USERPROFILE "autonomi"
+New-Item -ItemType Directory -Force -Path $autonomiPath
+Expand-Archive -Path $archivePath -DestinationPath $autonomiPath -Force
 Remove-Item $archivePath
-$safeupExePath = Join-Path $safePath "safeup.exe"
+$safeupExePath = Join-Path $autonomiPath "safeup.exe"
 
 $currentPath = [Environment]::GetEnvironmentVariable("PATH", [EnvironmentVariableTarget]::User)
-if ($currentPath -notlike "*$safePath*") {
-    $newPath = $currentPath + ";" + $safePath
+if ($currentPath -notlike "*$autonomiPath*") {
+    $newPath = $currentPath + ";" + $autonomiPath
     [Environment]::SetEnvironmentVariable("PATH", $newPath, [EnvironmentVariableTarget]::User)
-    Write-Host "Added $safePath to user PATH"
+    Write-Host "Added $autonomiPath to user PATH"
 } else {
-    Write-Host "Path $safePath is already in user PATH"
+    Write-Host "Path $autonomiPath is already in user PATH"
 }
 
 Write-Host "You may need to start a new session for safeup to become available."

--- a/install.sh
+++ b/install.sh
@@ -92,8 +92,8 @@ function install_safeup() {
   else
     target_dir="$HOME/.local/bin"
     mkdir -p "$target_dir"
-    mkdir -p "$HOME/.config/safe"
-    cat << 'EOF' > ~/.config/safe/env
+    mkdir -p "$HOME/.config/autonomi"
+    cat << 'EOF' > ~/.config/autonomi/env
 #!/bin/sh
 case ":${PATH}:" in
     *:"$HOME/.local/bin":*)
@@ -103,7 +103,7 @@ case ":${PATH}:" in
         ;;
 esac
 EOF
-  echo "source $HOME/.config/safe/env" >> "$HOME/.bashrc"
+  echo "source $HOME/.config/autonomi/env" >> "$HOME/.bashrc"
   fi
 
   temp_dir=$(mktemp -d)
@@ -129,7 +129,7 @@ function post_install() {
   else
     printf "\n"
     echo "The safeup binary has been installed, but it's not available in this session."
-    echo "You must either run 'source ~/.config/safe/env' in this session, or start a new session."
+    echo "You must either run 'source ~/.config/autonomi/env' in this session, or start a new session."
     echo "When safeup is available, please run 'safeup --help' to see how to install network components."
   fi
 }

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -24,7 +24,7 @@ lazy_static! {
         let mut m = HashMap::new();
         m.insert(
             AssetType::Client,
-            "https://sn-cli.s3.eu-west-2.amazonaws.com",
+            "https://autonomi-cli.s3.eu-west-2.amazonaws.com",
         );
         m.insert(
             AssetType::Node,
@@ -44,7 +44,7 @@ pub(crate) async fn process_install_cmd(
     version: Option<String>,
     no_modify_shell_profile: bool,
 ) -> Result<()> {
-    let safe_config_dir_path = get_safe_config_dir_path()?;
+    let autonomi_config_dir_path = get_autonomi_config_dir_path()?;
     let dest_dir_path = if let Some(path) = custom_path {
         path
     } else {
@@ -62,7 +62,7 @@ pub(crate) async fn process_install_cmd(
         crate::install::configure_shell_profile(
             &dest_dir_path.clone(),
             &get_shell_profile_path()?,
-            &safe_config_dir_path.join("env"),
+            &autonomi_config_dir_path.join("env"),
         )
         .await?
     }
@@ -71,8 +71,8 @@ pub(crate) async fn process_install_cmd(
 }
 
 pub(crate) async fn process_update_cmd() -> Result<()> {
-    let safe_config_dir_path = get_safe_config_dir_path()?;
-    let settings_file_path = safe_config_dir_path.join("safeup.json");
+    let autonomi_config_dir_path = get_autonomi_config_dir_path()?;
+    let settings_file_path = autonomi_config_dir_path.join("safeup.json");
     let settings = Settings::read(&settings_file_path)?;
     let release_repo = <dyn SafeReleaseRepoActions>::default_config();
 
@@ -115,8 +115,8 @@ pub(crate) async fn process_update_cmd() -> Result<()> {
 }
 
 pub(crate) fn process_ls_command() -> Result<()> {
-    let safe_config_dir_path = get_safe_config_dir_path()?;
-    let settings_file_path = safe_config_dir_path.join("safeup.json");
+    let autonomi_config_dir_path = get_autonomi_config_dir_path()?;
+    let settings_file_path = autonomi_config_dir_path.join("safeup.json");
     let settings = Settings::read(&settings_file_path)?;
     let mut table = Table::new();
     table.add_row(Row::new(vec![
@@ -161,13 +161,13 @@ async fn do_install_binary(
     )
     .await?;
 
-    let safe_config_dir_path = get_safe_config_dir_path()?;
-    let settings_file_path = safe_config_dir_path.join("safeup.json");
+    let autonomi_config_dir_path = get_autonomi_config_dir_path()?;
+    let settings_file_path = autonomi_config_dir_path.join("safeup.json");
     let mut settings = Settings::read(&settings_file_path)?;
     match asset_type {
         AssetType::Client => {
-            settings.safe_path = Some(bin_path);
-            settings.safe_version = Some(installed_version);
+            settings.autonomi_path = Some(bin_path);
+            settings.autonomi_version = Some(installed_version);
         }
         AssetType::Node => {
             settings.safenode_path = Some(bin_path);
@@ -253,28 +253,28 @@ fn get_shell_profile_path() -> Result<PathBuf> {
     Ok(home_dir_path.join(profile_file_name))
 }
 
-fn get_safe_config_dir_path() -> Result<PathBuf> {
+fn get_autonomi_config_dir_path() -> Result<PathBuf> {
     let config_dir_path = dirs_next::config_dir()
         .ok_or_else(|| eyre!("Could not retrieve user's config directory"))?;
-    let safe_config_dir_path = config_dir_path.join("safe");
-    std::fs::create_dir_all(safe_config_dir_path.clone())?;
-    Ok(safe_config_dir_path)
+    let autonomi_config_dir_path = config_dir_path.join("autonomi");
+    std::fs::create_dir_all(autonomi_config_dir_path.clone())?;
+    Ok(autonomi_config_dir_path)
 }
 
 #[cfg(target_os = "windows")]
 fn get_default_install_path() -> Result<PathBuf> {
     let home_dir_path =
         dirs_next::home_dir().ok_or_else(|| eyre!("Could not retrieve user's home directory"))?;
-    let safe_dir_path = home_dir_path.join("safe");
-    std::fs::create_dir_all(safe_dir_path.clone())?;
-    Ok(safe_dir_path)
+    let autonomi_dir_path = home_dir_path.join("autonomi");
+    std::fs::create_dir_all(autonomi_dir_path.clone())?;
+    Ok(autonomi_dir_path)
 }
 
 #[cfg(target_family = "unix")]
 fn get_default_install_path() -> Result<PathBuf> {
     let home_dir_path =
         dirs_next::home_dir().ok_or_else(|| eyre!("Could not retrieve user's home directory"))?;
-    let safe_dir_path = home_dir_path.join(".local").join("bin");
-    std::fs::create_dir_all(safe_dir_path.clone())?;
-    Ok(safe_dir_path)
+    let autonomi_dir_path = home_dir_path.join(".local").join("bin");
+    std::fs::create_dir_all(autonomi_dir_path.clone())?;
+    Ok(autonomi_dir_path)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,14 +29,14 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Install the safe client binary.
+    /// Install the autonomi client binary.
     ///
     /// The location is platform specific:
     /// - Linux/macOS: $HOME/.local/bin
-    /// - Windows: C:\Users\<username>\safe
+    /// - Windows: C:\Users\<username>\autonomi
     ///
     /// On Linux/macOS, the Bash shell profile will be modified to add $HOME/.local/bin to the PATH
-    /// variable. On Windows, the user Path variable will be modified to add C:\Users\<username>\safe.
+    /// variable. On Windows, the user Path variable will be modified to add C:\Users\<username>\autonomi.
     #[clap(verbatim_doc_comment)]
     Client {
         /// Override the default installation path.
@@ -57,10 +57,10 @@ enum Commands {
     ///
     /// The location is platform specific:
     /// - Linux/macOS: $HOME/.local/bin
-    /// - Windows: C:\Users\<username>\safe
+    /// - Windows: C:\Users\<username>\autonomi
     ///
     /// On Linux/macOS, the Bash shell profile will be modified to add $HOME/.local/bin to the PATH
-    /// variable. On Windows, the user Path variable will be modified to add C:\Users\<username>\safe.
+    /// variable. On Windows, the user Path variable will be modified to add C:\Users\<username>\autonomi.
     #[clap(verbatim_doc_comment)]
     Node {
         /// Override the default installation path.
@@ -81,10 +81,10 @@ enum Commands {
     ///
     /// The location is platform specific:
     /// - Linux/macOS: $HOME/.local/bin
-    /// - Windows: C:\Users\<username>\safe
+    /// - Windows: C:\Users\<username>\autonomi
     ///
     /// On Linux/macOS, the Bash shell profile will be modified to add $HOME/.local/bin to the PATH
-    /// variable. On Windows, the user Path variable will be modified to add C:\Users\<username>\safe.
+    /// variable. On Windows, the user Path variable will be modified to add C:\Users\<username>\autonomi.
     #[clap(verbatim_doc_comment)]
     NodeManager {
         /// Override the default installation path.
@@ -120,7 +120,7 @@ async fn main() -> Result<()> {
         }) => {
             println!("**************************************");
             println!("*                                    *");
-            println!("*          Installing safe           *");
+            println!("*        Installing autonomi         *");
             println!("*                                    *");
             println!("**************************************");
             install::check_prerequisites()?;

--- a/src/update.rs
+++ b/src/update.rs
@@ -51,8 +51,8 @@ mod test {
     #[test]
     fn perform_upgrade_assessment_should_indicate_no_previous_installation() -> Result<()> {
         let settings = Settings {
-            safe_path: None,
-            safe_version: None,
+            autonomi_path: None,
+            autonomi_version: None,
             safenode_path: Some(PathBuf::from("/home/chris/.local/bin/safenode")),
             safenode_version: Some(Version::new(0, 83, 13)),
             safenode_manager_path: Some(PathBuf::from("/home/chris/.local/bin/safenode-manager")),
@@ -63,8 +63,8 @@ mod test {
         assert_matches!(decision, UpdateAssessmentResult::NoPreviousInstallation);
 
         let settings = Settings {
-            safe_path: Some(PathBuf::from("/home/chris/.local/safe")),
-            safe_version: Some(Version::new(0, 78, 26)),
+            autonomi_path: Some(PathBuf::from("/home/user/.local/autonomi")),
+            autonomi_version: Some(Version::new(0, 78, 26)),
             safenode_path: None,
             safenode_version: None,
             safenode_manager_path: Some(PathBuf::from("/home/chris/.local/bin/safenode-manager")),
@@ -75,8 +75,8 @@ mod test {
         assert_matches!(decision, UpdateAssessmentResult::NoPreviousInstallation);
 
         let settings = Settings {
-            safe_path: Some(PathBuf::from("/home/chris/.local/safe")),
-            safe_version: Some(Version::new(0, 78, 26)),
+            autonomi_path: Some(PathBuf::from("/home/user/.local/autonomi")),
+            autonomi_version: Some(Version::new(0, 78, 26)),
             safenode_path: Some(PathBuf::from("/home/chris/.local/bin/safenode")),
             safenode_version: Some(Version::new(0, 83, 13)),
             safenode_manager_path: None,
@@ -92,8 +92,8 @@ mod test {
     #[test]
     fn perform_upgrade_assessment_should_indicate_we_are_at_latest_version() -> Result<()> {
         let settings = Settings {
-            safe_path: Some(PathBuf::from("/home/chris/.local/safe")),
-            safe_version: Some(Version::new(0, 78, 26)),
+            autonomi_path: Some(PathBuf::from("/home/user/.local/autonomi")),
+            autonomi_version: Some(Version::new(0, 78, 26)),
             safenode_path: Some(PathBuf::from("/home/chris/.local/bin/safenode")),
             safenode_version: Some(Version::new(0, 83, 13)),
             safenode_manager_path: Some(PathBuf::from("/home/chris/.local/bin/safenode-manager")),
@@ -119,8 +119,8 @@ mod test {
     fn perform_upgrade_assessment_latest_version_is_less_than_current_should_return_error(
     ) -> Result<()> {
         let settings = Settings {
-            safe_path: Some(PathBuf::from("/home/chris/.local/safe")),
-            safe_version: Some(Version::new(0, 78, 26)),
+            autonomi_path: Some(PathBuf::from("/home/user/.local/autonomi")),
+            autonomi_version: Some(Version::new(0, 78, 26)),
             safenode_path: Some(PathBuf::from("/home/chris/.local/bin/safenode")),
             safenode_version: Some(Version::new(0, 83, 13)),
             safenode_manager_path: Some(PathBuf::from("/home/chris/.local/bin/safenode-manager")),
@@ -164,8 +164,8 @@ mod test {
     fn perform_upgrade_assessment_should_perform_update_when_latest_patch_version_is_greater(
     ) -> Result<()> {
         let settings = Settings {
-            safe_path: Some(PathBuf::from("/home/chris/.local/safe")),
-            safe_version: Some(Version::new(0, 78, 26)),
+            autonomi_path: Some(PathBuf::from("/home/user/.local/autonomi")),
+            autonomi_version: Some(Version::new(0, 78, 26)),
             safenode_path: Some(PathBuf::from("/home/chris/.local/bin/safenode")),
             safenode_version: Some(Version::new(0, 83, 13)),
             safenode_manager_path: Some(PathBuf::from("/home/chris/.local/bin/safenode-manager")),
@@ -191,8 +191,8 @@ mod test {
     fn perform_upgrade_assessment_should_perform_update_when_latest_minor_version_is_greater(
     ) -> Result<()> {
         let settings = Settings {
-            safe_path: Some(PathBuf::from("/home/chris/.local/safe")),
-            safe_version: Some(Version::new(0, 78, 26)),
+            autonomi_path: Some(PathBuf::from("/home/user/.local/autonomi")),
+            autonomi_version: Some(Version::new(0, 78, 26)),
             safenode_path: Some(PathBuf::from("/home/chris/.local/bin/safenode")),
             safenode_version: Some(Version::new(0, 83, 13)),
             safenode_manager_path: Some(PathBuf::from("/home/chris/.local/bin/safenode-manager")),
@@ -218,8 +218,8 @@ mod test {
     fn perform_upgrade_assessment_should_perform_update_when_latest_major_version_is_greater(
     ) -> Result<()> {
         let settings = Settings {
-            safe_path: Some(PathBuf::from("/home/chris/.local/safe")),
-            safe_version: Some(Version::new(0, 78, 26)),
+            autonomi_path: Some(PathBuf::from("/home/user/.local/autonomi")),
+            autonomi_version: Some(Version::new(0, 78, 26)),
             safenode_path: Some(PathBuf::from("/home/chris/.local/bin/safenode")),
             safenode_version: Some(Version::new(0, 83, 13)),
             safenode_manager_path: Some(PathBuf::from("/home/chris/.local/bin/safenode-manager")),


### PR DESCRIPTION
The `client` command will now retrieve and install the `autonomi` binary rather than `safe`.

The installer scripts have also been updated to use the new settings locations.

BREAKING CHANGE: the binaries and settings now use a path with `autonomi` rather than `safe`. The
old settings file is now also incompatible because it is at a different location and the field names
have changed, so they will serialize/deserialize to/from different values. Fetching a different
binary itself is also a breaking change.

The tests in the PR workflow are updated to work with the newer versions of the `safenode` and
`safenode-manager` binaries, which have new output for `--version`. We need to use RC versions just
now because those are the only ones that have been released with the new versioning information.