### PR TITLE
fix: use correct crate for `autonomi` version

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,9 +10,9 @@ on: pull_request
 env:
   RUST_BACKTRACE: 1
   RUSTFLAGS: "-D warnings"
-  CLIENT_VERSION: 0.1.1-rc.1
-  NODE_VERSION: 0.112.0-rc.1
-  NODE_MANAGER_VERSION: 0.11.0-rc.1
+  CLIENT_VERSION: 0.1.2
+  NODE_VERSION: 0.112.1
+  NODE_MANAGER_VERSION: 0.11.0
 
 jobs:
   # The code in this crate uses lots of conditional compilation for cross-platform capabilities.
@@ -331,4 +331,3 @@ jobs:
 
       - name: dry run publish
         run: cargo publish --dry-run
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ semver = "1.0.4"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-sn-releases = "0.3.0"
+sn-releases = "0.3.1"
 tempfile = "3.8.1"
 textwrap = "0.16.0"
 tokio = { version = "1.26", features = ["full"] }


### PR DESCRIPTION
The `sn-releases` version was upgraded to the newest version, which uses the correct crate for the `autonomi` binary.